### PR TITLE
Improvements on AddModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vuetorrent",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vuetorrent",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve",

--- a/src/components/Modals/AddModal.vue
+++ b/src/components/Modals/AddModal.vue
@@ -56,6 +56,13 @@
                                 </v-col>
                             </v-row>
 
+                            <v-select
+                                v-model="category"
+                                :items="availableCategories"
+                                label="Category"
+                                prepend-icon="tag"
+                            ></v-select>
+
                             <v-text-field
                                 v-model="directory"
                                 :placeholder="savepath"
@@ -98,7 +105,9 @@ export default {
     data() {
         return {
             files: [],
+            category: null,
             directory: '',
+            skip_checking: false,
             inputRules: [
                 v =>
                     v.indexOf('magnet') > -1 ||
@@ -115,9 +124,10 @@ export default {
         submit() {
             if (this.files.length || this.url) {
                 let torrents = []
-                let params = { urls: null }
+                let params = { urls: null, autoTMM: true }
                 if (this.files.length) torrents.push(...this.files)
                 if (this.url) params.urls = this.url
+                if (this.category) params.category = this.category
                 if (this.directory) {
                     params.savepath = this.directory
                     params.autoTMM = false
@@ -134,12 +144,13 @@ export default {
         resetForm() {
             this.url = null
             this.files = []
+            this.category = null
             this.directory = null
             this.skip_checking = null
         }
     },
     computed: {
-        ...mapGetters(['getSettings']),
+        ...mapGetters(['getSettings', 'getCategories']),
         validFile() {
             return this.Files.length > 0
         },
@@ -147,8 +158,16 @@ export default {
             return this.$vuetify.breakpoint.xsOnly
         },
         savepath() {
-            return this.getSettings().savePath
+            let savePath = this.getSettings().save_path
+            if (this.category) savePath = this.getCategories()[this.category].savePath
+            return savePath
+        },
+        availableCategories() {
+            return Object.keys(this.getCategories())
         }
+    },
+    created() {
+        this.$store.commit('FETCH_SETTINGS')
     }
 }
 </script>

--- a/src/components/Modals/AddModal.vue
+++ b/src/components/Modals/AddModal.vue
@@ -56,12 +56,13 @@
                                 </v-col>
                             </v-row>
 
-                            <v-select
+                            <v-combobox
                                 v-model="category"
                                 :items="availableCategories"
+                                clearable
                                 label="Category"
                                 prepend-icon="tag"
-                            ></v-select>
+                            ></v-combobox>
 
                             <v-text-field
                                 v-model="directory"
@@ -159,7 +160,11 @@ export default {
         },
         savepath() {
             let savePath = this.getSettings().save_path
-            if (this.category) savePath = this.getCategories()[this.category].savePath
+            if (this.category) {
+                savePath += this.category
+                let category_path = this.getCategories()[this.category].savePath
+                if (category_path) savePath = category_path
+            }
             return savePath
         },
         availableCategories() {
@@ -168,6 +173,7 @@ export default {
     },
     created() {
         this.$store.commit('FETCH_SETTINGS')
+        this.$store.commit('FETCH_CATEGORIES')
     }
 }
 </script>

--- a/src/components/Modals/AddModal.vue
+++ b/src/components/Modals/AddModal.vue
@@ -62,6 +62,11 @@
                                 label="Download Directory"
                                 prepend-icon="folder"
                             ></v-text-field>
+
+                            <v-checkbox
+                                v-model="skip_checking"
+                                label="Skip hash check"
+                            ></v-checkbox>
                         </v-container>
                     </v-form>
                 </v-card-text>
@@ -113,7 +118,11 @@ export default {
                 let params = { urls: null }
                 if (this.files.length) torrents.push(...this.files)
                 if (this.url) params.urls = this.url
-                if (this.directory) params.savepath = this.directory
+                if (this.directory) {
+                    params.savepath = this.directory
+                    params.autoTMM = false
+                }
+                if (this.skip_checking) params.skip_checking = this.skip_checking
 
                 qbit.addTorrents(params, torrents)
 
@@ -126,6 +135,7 @@ export default {
             this.url = null
             this.files = []
             this.directory = null
+            this.skip_checking = null
         }
     },
     computed: {


### PR DESCRIPTION
- Added a checkbox in the add torrent modal to allow users that upload content skip the file hash check

- Set as false the autoTMM param to download the torrent into the specified path

- Added a combobox to select the torrent category on adding

![image](https://user-images.githubusercontent.com/9284052/96146255-63971c00-0f06-11eb-8b6b-d585589b5e3b.png)
