### PR TITLE
Typo in sidebar filter

### DIFF
--- a/src/components/Navbar/FilterSelect.vue
+++ b/src/components/Navbar/FilterSelect.vue
@@ -62,7 +62,7 @@ export default {
             { value: 'stalled', name: 'Stalled' },
             { value: 'stalled_uploading', name: 'Stalled Uploading' },
             { value: 'stalled_downloading', name: 'Stalled Downloading' },
-            { value: 'errored', name: 'Erorred' }
+            { value: 'errored', name: 'Errored' }
         ],
         selectedState: { value: 'all', name: 'All' },
         selectedCategory: null


### PR DESCRIPTION
# Improvements

Update typo from `Erorred` to `Errored`.

![image](https://user-images.githubusercontent.com/12074633/97666869-ed8dcb80-1a54-11eb-93ba-6c7f9e177c42.png)



