### PR TITLE
valid sort options default for /info API

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -42,7 +42,7 @@ export default new Vuex.Store({
         selected_torrents: [],
         authenticated: false,
         sort_options: {
-            sort: 'added_on',
+            sort: null,
             reverse: true,
             hashes: [],
             filter: null

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -42,7 +42,7 @@ export default new Vuex.Store({
         selected_torrents: [],
         authenticated: false,
         sort_options: {
-            sort: 'default',
+            sort: 'added_on',
             reverse: true,
             hashes: [],
             filter: null


### PR DESCRIPTION
Using docker linuxserver/qbittorrent:latest, queried version 4.3.2

```
root@d60a614b4c8d:/# qbittorrent-nox -v
qBittorrent v4.3.2
```
the `/info` API: `/api/v2/torrents/info?sort=default&reverse=true&hashes=&filter=all`
returns:
400 `'sort' parameter is invalid`

So I fixed the App default value with one that exists in the API, as their documentation tells

> They can be sorted using any field of the response's JSON array

"default" is not a valid one, to have a default, we should **omit** the sort parameter altogether

**edit**: I added another commit to omit the sort parameter as default 😉 