### PR TITLE
Fixed white line below pagination that is visible in dark theme mode

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -137,7 +137,12 @@
             </template>
           </v-list-item>
         </v-list>
-        <v-row v-if="(pageCount > 1) && !hasSearchFilter" xs12 justify="center">
+        <v-row
+          v-if="(pageCount > 1) && !hasSearchFilter"
+          xs12
+          justify="center"
+          class="mb-0"
+        >
           <v-col>
             <v-container>
               <v-pagination


### PR DESCRIPTION
# Fixes
- Fixed white line below pagination that is visible in dark theme mode

Before
![2021-01-29__14-41-34](https://user-images.githubusercontent.com/14232100/106280911-2c474380-6247-11eb-88df-9e99e563c49b.png)
After
![2021-01-29__15-33-59](https://user-images.githubusercontent.com/14232100/106281134-7af4dd80-6247-11eb-9211-8a33845efcaa.png)

Also verified for mobile view. Looks OK.


