### PR TITLE
Fixed forceDL misspeling that caused forced downloading torrents to be displayed as Failed

### DIFF
--- a/src/models/Torrent.js
+++ b/src/models/Torrent.js
@@ -35,12 +35,14 @@ export default class Torrent {
 
   formatState(state) {
     switch (state) {
-      case 'forceDL':
+      case 'forcedDL':
+        return '[F] Downloading'
       case 'downloading':
         return 'Downloading'
       case 'metaDL':
         return 'Metadata'
       case 'forcedUP':
+        return '[F] Seeding'
       case 'uploading':
       case 'stalledUP':
         return 'Seeding'


### PR DESCRIPTION
# Fixes
- fixed forceDL misspelling that caused forced downloading torrents to display as Failed
# Improvements
- added identification for forced for both downloading and uploading torrents


