### PR TITLE
Update vue.config.js

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -6,7 +6,7 @@ const vueTorrentPort = process.env['VUETORRENT_PORT'] ?? 8000
 module.exports = {
   pwa: {
     name: 'VueTorrent', //PWApp name
-    //themeColor: '#597566', //PWA title bar color ( windows 10 PWA, android web browser and PWA address bar color )
+    themeColor: '#597566', //PWA title bar color ( windows 10 PWA, android web browser and PWA address bar color )
     manifestOptions: {
       background_color: '#eeeeee' //background color for android PWA splash page
     },
@@ -42,6 +42,7 @@ module.exports = {
     },
     host: '0.0.0.0',
     port: `${vueTorrentPort}`,
+    disableHostCheck: true, //allows https proxy for dev server
     proxy: {
       '/api': {
         target: `http://localhost:${qBittorrentPort}`

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,7 +13,7 @@ module.exports = {
     workboxOptions: {
       skipWaiting: true
     }
-    
+  },
   chainWebpack: config => {
     config
       .plugin('html')

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,6 +4,16 @@ const qBittorrentPort = process.env['QBITTORRENT_PORT'] ?? 8080
 const vueTorrentPort = process.env['VUETORRENT_PORT'] ?? 8000
 
 module.exports = {
+  pwa: {
+    name: 'VueTorrent', //PWApp name
+    //themeColor: '#597566', //PWA title bar color ( windows 10 PWA, android web browser and PWA address bar color )
+    manifestOptions: {
+      background_color: '#eeeeee' //background color for android PWA splash page
+    },
+    workboxOptions: {
+      skipWaiting: true
+    }
+    
   chainWebpack: config => {
     config
       .plugin('html')


### PR DESCRIPTION
edit colorcode " themeColor: '#597566' " to what do you want
"background_color" make show custom color on android PWA splash page.

# Features
- use custom color top bar for most of OS.
# Fixes
- Android splash images no longer appear black.

