### PR TITLE
Update mutations.js

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -53,8 +53,9 @@ export default {
     state.authenticated = payload
   },
   updateMainData: async state => {
-    const rid = state.rid ? state.rid : undefined
-    const res = await qbit.getMainData(rid)
+    //const rid = state.rid ? state.rid : undefined
+    //const res = await qbit.getMainData(rid)
+    const res = await qbit.getMainData(undefined)
 
     // status
     state.status = new Status(res.data.server_state, res.data.tags)

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -53,8 +53,6 @@ export default {
     state.authenticated = payload
   },
   updateMainData: async state => {
-    //const rid = state.rid ? state.rid : undefined
-    //const res = await qbit.getMainData(rid)
     const res = await qbit.getMainData(undefined)
 
     // status


### PR DESCRIPTION
I haven't yet understood the role for 'rid'.
However, I know that increasing the number of 'rid' hide the 'available tag lists'.

# Fixes
- After browsing the'Torrent Details' of several torrents, the list of available tags is hidden.