### PR TITLE
remove gesture feature on tabs

### DIFF
--- a/src/components/Modals/SettingsModal/SettingsModal.vue
+++ b/src/components/Modals/SettingsModal/SettingsModal.vue
@@ -34,7 +34,7 @@
             Tags & Categories
           </v-tab>
         </v-tabs>
-        <v-tabs-items v-model="tab" :touch="updateTab(tab)">
+        <v-tabs-items v-model="tab" touchless">
           <v-tab-item value="downloads">
             <Downloads :is-active="tab === 'downloads'" />
           </v-tab-item>

--- a/src/components/Modals/SettingsModal/Tabs/VueTorrent.vue
+++ b/src/components/Modals/SettingsModal/Tabs/VueTorrent.vue
@@ -12,7 +12,7 @@
         </v-tabs>
         <v-tabs-items
           v-model="tab"
-          :touch="updateTab(tab)"
+          touchless
         >
           <v-tab-item value="general">
             <General :is-active="tab === 'downloads'" />
@@ -39,11 +39,6 @@ export default {
   mixins: [FullScreenModal],
   data: () => ({
     tab: null
-  }),
-  methods: {
-    updateTab(tab) {
-      this.tab = tab
-    }
-  }
+  })
 }
 </script>

--- a/src/components/Modals/TorrentDetailModal/TorrentDetailModal.vue
+++ b/src/components/Modals/TorrentDetailModal/TorrentDetailModal.vue
@@ -40,7 +40,7 @@
             Tags & Categories
           </v-tab>
         </v-tabs>
-        <v-tabs-items v-model="tab" :touch="updateTab(tab)">
+        <v-tabs-items v-model="tab" touchless>
           <v-tab-item value="info">
             <info :is-active="tab === 'info'" :hash="hash" />
           </v-tab-item>

--- a/src/mixins/Modal.js
+++ b/src/mixins/Modal.js
@@ -15,9 +15,6 @@ export default {
   methods: {
     deleteModal() {
       setTimeout(() => this.$store.commit('DELETE_MODAL', this.guid), 100)
-    },
-    updateTab(tab) {
-      this.tab = tab
     }
   },
   beforeDestroy() {


### PR DESCRIPTION
When using a mobile device, a malfunction occurs due to the gesture function.
changing the order of items on the dashboard, the item is not removed from the screen when the item is drop, but is displayed in a superimposed manner.
and It can't use any horizontal scrolling on the 'torrent detail' page.

# Fixes
- A fatal gesture error occurs in draggable items or horizontal scrolling by the built-in gesture.


