### PR TITLE
chore: use process.env for version

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,6 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import Navbar from '@/components/Navbar/Navbar.vue'
-import { version } from '../package.json'
 import qbit from '@/services/qbit'
 import { General } from '@/mixins'
 
@@ -35,7 +34,7 @@ export default {
     }
   },
   created() {
-    this.$store.commit('SET_APP_VERSION', version)
+    this.$store.commit('SET_APP_VERSION', process.env['npm_package_version'])
     this.checkDeviceDarkTheme()
     this.checkAuthenticated()
   },


### PR DESCRIPTION
# chore

Use `process.env` for version instead of importing `package.json`. Completely unnecessary, but something I learned recently and could be better practice?

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
