### PR TITLE
Show connection status at the bottom of Navbar

### DIFF
--- a/src/components/Navbar/ConnectionStatus.vue
+++ b/src/components/Navbar/ConnectionStatus.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-tooltip top>
+    <template #activator="{ on }">
+      <div class="d-flex justify-center fill-height">
+        <v-icon class="white--text" v-on="on">
+          {{ currentIcon }}
+        </v-icon>
+      </div>
+    </template>
+
+    <span>{{ status || 'unknown' }}</span>
+  </v-tooltip>
+</template>
+
+<script>
+import {
+  mdiCheckNetwork,
+  mdiNetworkOff,
+  mdiCloseNetwork,
+  mdiHelpNetwork
+} from '@mdi/js'
+
+export default {
+  props: ['status'],
+  computed: {
+    currentIcon() {
+      const icons = {
+        connected: mdiCheckNetwork,
+        disconnected: mdiNetworkOff,
+        firewalled: mdiCloseNetwork
+      }
+      const icon = icons?.[this.status]
+
+      if (!this.status || !icon) return mdiHelpNetwork
+
+      return icon
+    }
+  }
+}
+</script>

--- a/src/components/Navbar/NavbarActions.vue
+++ b/src/components/Navbar/NavbarActions.vue
@@ -55,6 +55,9 @@
       </v-tooltip>
     </v-col>-->
     <v-col>
+      <connection-status :status="connectionStatus" />
+    </v-col>
+    <v-col>
       <v-tooltip top>
         <template #activator="{ on }">
           <v-btn
@@ -78,10 +81,22 @@
 <script>
 import qbit from '@/services/qbit'
 import { mapGetters } from 'vuex'
-import { mdiBrightness4, mdiSpeedometerSlow, mdiBrightness7, mdiSpeedometer, mdiExitToApp, mdiBell, mdiBellOff } from '@mdi/js'
+import {
+  mdiBrightness4,
+  mdiSpeedometerSlow,
+  mdiBrightness7,
+  mdiSpeedometer,
+  mdiExitToApp,
+  mdiBell,
+  mdiBellOff
+} from '@mdi/js'
+import ConnectionStatus from './ConnectionStatus.vue'
 
 export default {
   name: 'BottomActions',
+  components: {
+    ConnectionStatus
+  },
   data: () => ({
     //commonStyle: 'primarytext--text',
     commonStyle: 'white--text',
@@ -104,11 +119,16 @@ export default {
     alarm() {
       return this.getAlarm()
     },
+    status() {
+      return this.getStatus()
+    },
     altSpeed() {
-      const status = this.getStatus()
-      if (status && status.altSpeed) return status.altSpeed
+      if (this.status && this.status.altSpeed) return this.status.altSpeed
 
       return null
+    },
+    connectionStatus() {
+      return this.status.status
     }
   },
   methods: {


### PR DESCRIPTION
# Connection status icon [feat]

Hey, thanks for a great project! Some time ago I was thinking about building alternative UI using the same stack, but when I found yours it was clear enough that there is no sense doing that.

Recently I was doing some network setup changes and found this little feature to be really missing - showing if connection port is open. To check that I had to use default web UI for some time, which, you know, is not the best experience :smile:. So here is my 5 cents and hopefully more to come.

4 icons will be shown for 4 states: _connected, disconnected, firewalled_ and when there is no status data, with a tooltip. Hopefully the placement is ok.
Please find screenshots below (all states on desktop + mobile view):

<img src="https://user-images.githubusercontent.com/13542569/116823601-115dd580-ab8e-11eb-9275-98a8fb04e617.png" width="550"> <img src="https://user-images.githubusercontent.com/13542569/116823603-16bb2000-ab8e-11eb-84db-073685b9e9d5.png" height="550">


# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
