### PR TITLE
Add more Chinese translation and set the language auto detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.14.0](https://www.github.com/WDaan/VueTorrent/compare/v0.13.0...v0.14.0) (2021-11-27)
+
+
+### Features
+
+* basic multilang support ([#320](https://www.github.com/WDaan/VueTorrent/issues/320)) ([a7cc03c](https://www.github.com/WDaan/VueTorrent/commit/a7cc03c3ba60f7dbc2d18fff78a0b5f5c6db4b1a))
+* run external program on torrent completion [#258](https://www.github.com/WDaan/VueTorrent/issues/258) ([93f89a6](https://www.github.com/WDaan/VueTorrent/commit/93f89a68ed3488fbb82dc0a433ac2da34e9274cc))
+
+
+### Bug Fixes
+
+* invisble close button on modal [#314](https://www.github.com/WDaan/VueTorrent/issues/314) [#297](https://www.github.com/WDaan/VueTorrent/issues/297) ([8001dc9](https://www.github.com/WDaan/VueTorrent/commit/8001dc91c738e4b9bfa9dd8a6b6b52249e727f5a))
+
+
+### Improvements
+
+* better share limit modal ([#316](https://www.github.com/WDaan/VueTorrent/issues/316)) ([9f2ca42](https://www.github.com/WDaan/VueTorrent/commit/9f2ca4230da46431965d6ed0777f465554926494))
+
 ## [0.13.0](https://www.github.com/WDaan/VueTorrent/compare/v0.12.0...v0.13.0) (2021-11-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetorrent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetorrent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/Modals/SettingsModal/Tabs/Downloads.vue
+++ b/src/components/Modals/SettingsModal/Tabs/Downloads.vue
@@ -64,26 +64,58 @@
       />
     </v-list-item>
     <v-list-item>
-      <v-row dense>
-        <v-col>
-          <v-checkbox
-            v-model="settings.temp_path_enabled"
-            hide-details
-            class="ma-0 pa-0"
-            label="Keep incomplete torrents in:"
-          />
-        </v-col>
-        <v-col>
-          <v-text-field
-            v-model="settings.temp_path"
-            class="mb-2"
-            outlined
-            dense
-            hide-details
-            :disabled="!settings.temp_path_enabled"
-          />
-        </v-col>
-      </v-row>
+      <v-checkbox
+        v-model="settings.temp_path_enabled"
+        hide-details
+        class="ma-0 pa-0"
+        label="Keep incomplete torrents in:"
+      />
+    </v-list-item>
+    <v-list-item v-if="settings.temp_path_enabled">
+      <v-text-field
+        v-model="settings.temp_path"
+        class="mb-2"
+        outlined
+        dense
+        hide-details
+      />
+    </v-list-item>
+    <v-list-item>
+      <v-checkbox
+        v-model="settings.autorun_enabled"
+        hide-details
+        class="ma-0 pa-0"
+        label="Autorun enabled:"
+      />
+    </v-list-item>
+    <v-list-item v-if="settings.autorun_enabled">
+      <v-text-field
+        v-model="settings.autorun_program"
+        class="mb-2"
+        outlined
+        dense
+        label="Autorun program"
+        hide-details
+      />
+    </v-list-item>
+    <v-list-item v-if="settings.autorun_enabled">
+      <v-card flat color="grey lighten-3">
+        <v-card-text>
+          <h5>Supported parameters (case sensitive):</h5>
+          <ul>
+            <li>%N: Torrent name </li>
+            <li>%L: Category</li>
+            <li>%G: Tags (separated by comma)</li>
+            <li>%F: Content path (same as root path for multi-file torrent)</li>
+            <li>%R: Root path (first torrent subdirectory path)</li>
+            <li>%D: Save path</li>
+            <li>%C: Number of files</li>
+            <li>%Z: Torrent size (bytes)</li>
+            <li>%T: Current tracker</li>
+            <li>%I: Info hash</li>
+          </ul>
+        </v-card-text>
+      </v-card>
     </v-list-item>
   </v-card>
 </template>

--- a/src/lang/index.js
+++ b/src/lang/index.js
@@ -6,7 +6,7 @@ import axios from 'axios'
 Vue.use(VueI18n)
 
 export const i18n = new VueI18n({
-  locale: 'en', // set locale
+  locale: navigator.language, // set locale
   fallbackLocale: 'en',
   messages: {
     en: messages

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -3,22 +3,66 @@ const locale = {
   category: '分类',
   settings: '设置',
 
+  /** Torrent */
+  torrent: {
+    title: '标题',
+    added: '添加时间',
+    availability: '可用性',
+    size: '大小',
+    progress: '进度'
+  },
   /** Navbar */
   navbar: {
     currentSpeed: '当前速率',
     freeSpace: '剩余磁盘空间',
     topActions: {
+      addTorrent: '打开种子',
+      resumeSelected: '继续选中的种子',
+      pauseSelected: '暂停选中的种子',
+      removeSelected: '删除选中的种子',
       openSettings: '打开设置',
-      searchNew: '搜索新的Torrent'
+      searchNew: '搜索新的种子'
     }
   },
 
   /** Modals */
   modals: {
     add: {
-      title: '添加新的Torrent',
+      title: '添加新的种子',
       selectFiles: '选择文件'
     }
+  },
+
+  /** Toast */
+  toast: {
+    loginSuccess: '登录成功！🎉',
+    loginFailed: '登录失败…😕',
+    settingsSaved: '设置保存成功！',
+    categorySaved: '分类编辑成功！'
+  },
+
+  /** RightClick **/
+  rightClick: {
+    resume: '继续',
+    forceResume: '强制继续',
+    pause: '暂停',
+    delete: '删除',
+    advanced: {
+      advanced: '高级',
+      changeLocation: '修改保存位置',
+      rename: '重命名'
+    },
+    prio: {
+      prio: '设置优先级',
+      top: '最高',
+      bottom: '最低',
+      increase: '提升',
+      decrease: '降低'
+    },
+    category: '设置分类',
+    limit: '设置限制',
+    copy: '赋值',
+    info: '显示详情'
   }
 }
 


### PR DESCRIPTION
# More Chinese Translation and Language Auto Detection. [feat]

## translation: more Chinese translation

Language translation is synchronized with English.

I found that all letters will be lowercased. Therefore, for the sake of beauty, I replace "Torrent" with the Chinese word "种子" commonly used in the Chinese Internet environment.

## feat: auto detect language

In the [documentation](https://github.com/intlify/vue-i18n-next/blob/master/docs-old/guide/fallback.md) of `vue-i18n`, it says:

> If a locale is given containing a territory and an optional dialect, the implicit fallback is activated automatically.
 
For example `zh-CN` would fallback:
1. `zh-CN`
2. `zh`

You have set the `fallbackLocale` to `en` in the previous commit. So I made this minor modification.

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
