### PR TITLE
fix: spelling mistake in README and "qBittorrent" casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p>&nbsp;</p>
 The sleekest looking WebUI for qBittorrent made with Vue.js!  
 
-> Vue, qBitorrent, Vuetify
+> Vue, qBittorrent, Vuetify
 </p>
 <p>&nbsp;</p>
 <p>&nbsp;</p>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="./favicon.ico?s=1">
-    <title>Qbittorrent</title>
+    <title>qBittorrent</title>
   </head>
   <body oncontextmenu='return false'>
     <noscript>

--- a/src/actions/DocumentTitle.js
+++ b/src/actions/DocumentTitle.js
@@ -4,7 +4,7 @@ import store from '../store'
 
 export class DocumentTitle {
   static setDefault() {
-    this.set('Qbittorrent')
+    this.set('qBittorrent')
   }
 
   static setGlobalSpeed() {

--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -18,7 +18,7 @@
           { 'subheading ml-0': $vuetify.breakpoint.smAndDown }
         ]"
       >
-        <span class="font-weight-light">Qbit</span>
+        <span class="font-weight-light">qBit</span>
         <span>torrent</span>
       </v-toolbar-title>
       <v-spacer />


### PR DESCRIPTION
# Fix spelling mistake in README

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
