### PR TITLE
Prefix enviromental variables according to Vue Cli documentation

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -2,9 +2,9 @@ const webpack = require('webpack')
 
 const iconVersion = 22 //fingerprint
 
-const qBittorrentPort = process.env['QBITTORRENT_PORT'] ?? 8080
-const vueTorrentPort = process.env['VUETORRENT_PORT'] ?? 8000
-const proxyTarget = process.env['QBITTORRENT_TARGET'] ?? 'http://localhost'
+const qBittorrentPort = process.env['VUE_APP_QBITTORRENT_PORT'] ?? 8080
+const vueTorrentPort = process.env['VUE_APP_VUETORRENT_PORT'] ?? 8000
+const proxyTarget = process.env['VUE_APP_QBITTORRENT_TARGET'] ?? 'http://localhost'
 
 module.exports = {
   pwa: {


### PR DESCRIPTION
# My Title [feat/fix/perf/chore]
In the file `vue.config.js` there are enviromental variables `QBITTORRENT_PORT`,  `VUETORRENT_PORT`, `QBITTORRENT_TARGET` are not picked up by Vue CLI unless they have a prefix `VUE_APP_`.

This PR changes the name of enviromental variables so they can be used when you build or serve the app.

Now it would be possible to use a dotenv file for those enviromental variables.
# PR Checklist
- [*] I've started from master
- [*] I've only committed changes related to this PR
- [*] All Unit tests pass
- [*] I've removed all commented code
- [*] I've removed all unneeded console.log statements
