### PR TITLE
fix: low visibility text in dark theme

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -76,6 +76,10 @@ $sideborder-margin: 6px;
     border-color: #{$primary} !important;
 }
 
+.v-application a {
+    color: inherit !important;
+}  
+
 .noselect {
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */


### PR DESCRIPTION
# fix: low visibility text in dark theme
Links with `a` tags have low visibility when using the dark theme.

## Old:
![light-old](https://user-images.githubusercontent.com/1868568/157884565-21ca9316-7c86-4175-abf3-ddd91a46b3f7.png)
![old](https://user-images.githubusercontent.com/1868568/157884585-930c0c9a-81ba-4f2f-9bd4-b927cc7f11ea.png)

## New:
![light-new](https://user-images.githubusercontent.com/1868568/157884607-63995ed9-85f0-418d-8329-78fb67537555.png)
![new](https://user-images.githubusercontent.com/1868568/157884617-40ddd025-1cbc-4f4f-85ff-5a3126ea465a.png)


# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
