### PR TITLE
fix: search results not loading until search stopped

### DIFF
--- a/src/components/Modals/SearchModal/SearchModal.vue
+++ b/src/components/Modals/SearchModal/SearchModal.vue
@@ -150,8 +150,8 @@ export default {
           if (status === 'Stopped') {
             clearInterval(this.search.interval)
             this.search.interval = null
-            await this.getResults()
           }
+          await this.getResults()
         }, 500)
       }
     },
@@ -165,13 +165,13 @@ export default {
     async getResults() {
       const data = await qbit.getSearchResults(this.search.id)
       this.search.results = data.results
-      this.loading = false
     },
     downloadTorrent(item) {
       this.createModal('addModal', { initialMagnet: item.fileUrl })
     },
     stopSearch() {
       qbit.stopSearch(this.search.id)
+      this.loading = false
     },
     close() {
       this.dialog = false

--- a/src/services/qbit.js
+++ b/src/services/qbit.js
@@ -393,8 +393,7 @@ class Qbit {
 
   getSearchResults(id) {
     return this.execute('post', '/search/results', {
-      id,
-      limit: 50
+      id
     })
   }
 }


### PR DESCRIPTION
# fix: search results not loading until search stopped
Search results are not visible until user stops the search. This behavior is different from desktop clients.
Also, search always returns 50 total results no matter what.

## Old
![old](https://user-images.githubusercontent.com/1868568/157889329-26b1eddf-2e33-438a-87c8-4376dafcf857.gif)

## New
![new](https://user-images.githubusercontent.com/1868568/157889359-1ebbd127-15b8-4623-91c4-5ef15fad2901.gif)


# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
