### PR TITLE
Fix lint errors in src/lang/id.js

### DIFF
--- a/src/lang/id.js
+++ b/src/lang/id.js
@@ -1,84 +1,83 @@
 const locale = {
-    /** General */
-    category: 'kategori',
-    settings: 'pengaturan',
-    pause: 'jeda',
-    delete: 'hapus',
-    save: 'simpan',
-    cancel: 'batalkan',
-    confirm: 'konfirmasi',
-  
-    /** Torrent */
-    torrent: {
-      title: 'judul',
-      added: 'ditambahkan pada',
-      availability: 'ketersediaan',
-      size: 'ukuran',
-      progress: 'progres',
-      directory: 'direktori',
-      downloaded: 'didownload',
-      uploaded: 'diupload',
-      created: 'dibuat oleh',
-      comments: 'komentar'
+  /** General */
+  category: 'kategori',
+  settings: 'pengaturan',
+  pause: 'jeda',
+  delete: 'hapus',
+  save: 'simpan',
+  cancel: 'batalkan',
+  confirm: 'konfirmasi',
+
+  /** Torrent */
+  torrent: {
+    title: 'judul',
+    added: 'ditambahkan pada',
+    availability: 'ketersediaan',
+    size: 'ukuran',
+    progress: 'progres',
+    directory: 'direktori',
+    downloaded: 'didownload',
+    uploaded: 'diupload',
+    created: 'dibuat oleh',
+    comments: 'komentar'
+  },
+  /** Navbar */
+  navbar: {
+    currentSpeed: 'kecepatan sekarang',
+    freeSpace: 'ruang bebas',
+    topActions: {
+      addTorrent: 'tambah torrent',
+      resumeSelected: 'lanjutkan torrent yang dipilih',
+      pauseSelected: 'jeda torrent yang dipilih',
+      removeSelected: 'hapus torrent yang dipilih',
+      openSettings: 'buka pengaturan',
+      searchNew: 'cari torrent baru'
     },
-    /** Navbar */
-    navbar: {
-      currentSpeed: 'kecepatan sekarang',
-      freeSpace: 'ruang bebas',
-      topActions: {
-        addTorrent: 'tambah torrent',
-        resumeSelected: 'lanjutkan torrent yang dipilih',
-        pauseSelected: 'jeda torrent yang dipilih',
-        removeSelected: 'hapus torrent yang dipilih',
-        openSettings: 'buka pengaturan',
-        searchNew: 'cari torrent baru'
-      },
-      sessionStats: {
-        tooltip: 'Sejak terakhir kali qBittorrent dijalankan ulang.'
-      }
-    },
-  
-    /** Modals */
-    modals: {
-      add: {
-        title: 'Tambahkan Torrent baru',
-        selectFiles: 'Pilih berkas anda'
-      },
-      delete: {
-        check: 'Dan hapus berkas dari penyimpanan'
-      }
-    },
-  
-    /** Toast */
-    toast: {
-      loginSuccess: 'Berhasil masuk! 🎉',
-      loginFailed: 'Gagal masuk 😕',
-      settingsSaved: 'Pengaturan sukses disimpan!',
-      categorySaved: 'Kategori sukses diubah!'
-    },
-  
-    /** RightClick **/
-    rightClick: {
-      resume: 'lanjutkan',
-      forceResume: 'paksa lanjutkan',
-      advanced: {
-        advanced: 'lebih lanjut',
-        changeLocation: 'ubah lokasi',
-        rename: 'ubah nama'
-      },
-      prio: {
-        prio: 'tetapkan prioritas',
-        top: 'atas',
-        bottom: 'bawah',
-        increase: 'tingkatkan',
-        decrease: 'turunkan'
-      },
-      category: 'tetapkan kategori',
-      limit: 'tetapkan limit',
-      copy: 'salin',
-      info: 'tampilkan info'
+    sessionStats: {
+      tooltip: 'Sejak terakhir kali qBittorrent dijalankan ulang.'
     }
+  },
+
+  /** Modals */
+  modals: {
+    add: {
+      title: 'Tambahkan Torrent baru',
+      selectFiles: 'Pilih berkas anda'
+    },
+    delete: {
+      check: 'Dan hapus berkas dari penyimpanan'
+    }
+  },
+
+  /** Toast */
+  toast: {
+    loginSuccess: 'Berhasil masuk! 🎉',
+    loginFailed: 'Gagal masuk 😕',
+    settingsSaved: 'Pengaturan sukses disimpan!',
+    categorySaved: 'Kategori sukses diubah!'
+  },
+
+  /** RightClick **/
+  rightClick: {
+    resume: 'lanjutkan',
+    forceResume: 'paksa lanjutkan',
+    advanced: {
+      advanced: 'lebih lanjut',
+      changeLocation: 'ubah lokasi',
+      rename: 'ubah nama'
+    },
+    prio: {
+      prio: 'tetapkan prioritas',
+      top: 'atas',
+      bottom: 'bawah',
+      increase: 'tingkatkan',
+      decrease: 'turunkan'
+    },
+    category: 'tetapkan kategori',
+    limit: 'tetapkan limit',
+    copy: 'salin',
+    info: 'tampilkan info'
   }
+}
   
-  export default locale
-  
+export default locale


### PR DESCRIPTION
# Fix Lint Errors in `src/lang/id.js` [fix]

When running the development build using `npm run serve` on the master branch, there are a ton of lint errors stemming from formatting issues with `src/lang/id.js`. This PR resolves that issue.

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
