### PR TITLE
feat: add support for setting global speed limits

### DIFF
--- a/src/components/Core/SpeedCard.vue
+++ b/src/components/Core/SpeedCard.vue
@@ -1,10 +1,12 @@
 <template>
   <v-card
+    v-ripple
     flat
     rounded="md"
     color="secondary"
     class="speedCard"
     data-testid="SpeedCard"
+    @click="open"
   >
     <v-layout row align-center :class="color + '--text'">
       <v-flex v-if="icon" xs2 class="pl-1">
@@ -31,6 +33,8 @@
 </template>
 
 <script>
+import { General } from '@/mixins'
+
 export default {
   name: 'SpeedCard',
   filters: {
@@ -43,7 +47,13 @@ export default {
       return `${parseFloat((value / Math.pow(c, f)).toFixed(d))}`
     }
   },
-  props: ['color', 'icon', 'value']
+  mixins: [General],
+  props: ['color', 'icon', 'value'],
+  methods: {
+    open() {
+      this.createModal('SpeedLimitModal', { mode: this.color })
+    }
+  }
 }
 </script>
 
@@ -51,5 +61,6 @@ export default {
 .speedCard {
   padding: 20px 20px !important;
   font-size: 1.10em;
+  cursor: pointer;
 }
 </style>

--- a/src/components/Modals/SpeedLimitModal.vue
+++ b/src/components/Modals/SpeedLimitModal.vue
@@ -79,19 +79,19 @@ export default {
   async created() {
     switch (this.mode) {
       case 'download':
-        if (this.torrent) {
-          this.limit = this.torrent?.dl_limit > 0 ? this.limit = this.torrent.dl_limit / 1024 : '∞'
+        if (this.isGlobal()) {
+          const limit = await qbit.getGlobalDownloadLimit()
+          this.limit = this.formatLimit(limit)
         } else {
-          const { data: downLimit } = await qbit.getGlobalDownloadLimit()
-          this.limit = downLimit > 0 ? downLimit / 1024 : '∞'
+          this.limit = this.formatLimit(this.torrent?.dl_limit)
         }
         break
       case 'upload':
-        if (this.torrent) {
-          this.limit = this.torrent?.up_limit > 0 ? this.torrent.up_limit / 1024 : '∞'
+        if (this.isGlobal()) {
+          const limit = await qbit.getGlobalUploadLimit()
+          this.limit = this.formatLimit(limit)
         } else {
-          const { data: upLimit } = await qbit.getGlobalUploadLimit()
-          this.limit = upLimit > 0 ? upLimit / 1024 : '∞'
+          this.limit = this.formatLimit(this.torrent?.up_limit)
         }
         break
       default:
@@ -102,17 +102,17 @@ export default {
     setLimit() {
       switch (this.mode) {
         case 'download':
-          if (this.torrent) {
-            qbit.setDownloadLimit([this.hash], this.limit > 0 ? this.limit * 1024 : NaN)
+          if (this.isGlobal()) {
+            qbit.setGlobalDownloadLimit(this.exportLimit())
           } else {
-            qbit.setGlobalDownloadLimit(this.limit > 0 ? this.limit * 1024 : NaN)
+            qbit.setDownloadLimit([this.hash], this.exportLimit())
           }
           break
         case 'upload':
-          if (this.torrent) {
-            qbit.setUploadLimit([this.hash], this.limit > 0 ? this.limit * 1024 : NaN)
+          if (this.isGlobal()) {
+            qbit.setGlobalUploadLimit(this.exportLimit())
           } else {
-            qbit.setGlobalUploadLimit(this.limit > 0 ? this.limit * 1024 : NaN)
+            qbit.setUploadLimit([this.hash], this.exportLimit())
           }
           break
         default:
@@ -120,6 +120,15 @@ export default {
       }
       
       this.close()
+    },
+    isGlobal() {
+      return this.torrent ? false : true
+    },
+    formatLimit(limit) {
+      return limit > 0 ? limit / 1024 : '∞'
+    },
+    exportLimit() {
+      return this.limit > 0 ? this.limit * 1024 : NaN
     },
     close() {
       this.dialog = false

--- a/src/components/Modals/SpeedLimitModal.vue
+++ b/src/components/Modals/SpeedLimitModal.vue
@@ -76,13 +76,23 @@ export default {
       return this.$vuetify.breakpoint.xsOnly
     }
   },
-  created() {
+  async created() {
     switch (this.mode) {
       case 'download':
-        this.limit = this.torrent.dl_limit > 0 ? this.limit = this.torrent.dl_limit / 1024 : '∞'
+        if (this.torrent) {
+          this.limit = this.torrent?.dl_limit > 0 ? this.limit = this.torrent.dl_limit / 1024 : '∞'
+        } else {
+          const { data: downLimit } = await qbit.getGlobalDownloadLimit()
+          this.limit = downLimit > 0 ? downLimit / 1024 : '∞'
+        }
         break
       case 'upload':
-        this.limit = this.torrent.up_limit > 0 ? this.torrent.up_limit / 1024 : '∞'
+        if (this.torrent) {
+          this.limit = this.torrent?.up_limit > 0 ? this.torrent.up_limit / 1024 : '∞'
+        } else {
+          const { data: upLimit } = await qbit.getGlobalUploadLimit()
+          this.limit = upLimit > 0 ? upLimit / 1024 : '∞'
+        }
         break
       default:
         break
@@ -92,14 +102,23 @@ export default {
     setLimit() {
       switch (this.mode) {
         case 'download':
-          qbit.setDownloadLimit([this.hash], this.limit > 0 ? this.limit * 1024 : NaN)
+          if (this.torrent) {
+            qbit.setDownloadLimit([this.hash], this.limit > 0 ? this.limit * 1024 : NaN)
+          } else {
+            qbit.setGlobalDownloadLimit(this.limit > 0 ? this.limit * 1024 : NaN)
+          }
           break
         case 'upload':
-          qbit.setUploadLimit([this.hash], this.limit > 0 ? this.limit * 1024 : NaN)
+          if (this.torrent) {
+            qbit.setUploadLimit([this.hash], this.limit > 0 ? this.limit * 1024 : NaN)
+          } else {
+            qbit.setGlobalUploadLimit(this.limit > 0 ? this.limit * 1024 : NaN)
+          }
           break
         default:
           break
       }
+      
       this.close()
     },
     close() {

--- a/src/services/qbit.js
+++ b/src/services/qbit.js
@@ -225,12 +225,16 @@ class Qbit {
     return this.torrentAction('setUploadLimit', hashes, { limit })
   }
 
-  getGlobalDownloadLimit() {
-    return this.axios.get('/transfer/downloadLimit')
+  async getGlobalDownloadLimit() {
+    const { data } = this.axios.get('/transfer/downloadLimit')
+    
+    return data
   }
 
   getGlobalUploadLimit() {
-    return this.axios.get('/transfer/uploadLimit')
+    const { data } = this.axios.get('/transfer/uploadLimit')
+    
+    return data
   }
 
   setGlobalDownloadLimit(limit) {

--- a/src/services/qbit.js
+++ b/src/services/qbit.js
@@ -226,13 +226,13 @@ class Qbit {
   }
 
   async getGlobalDownloadLimit() {
-    const { data } = this.axios.get('/transfer/downloadLimit')
+    const { data } = await this.axios.get('/transfer/downloadLimit')
     
     return data
   }
 
-  getGlobalUploadLimit() {
-    const { data } = this.axios.get('/transfer/uploadLimit')
+  async getGlobalUploadLimit() {
+    const { data } = await this.axios.get('/transfer/uploadLimit')
     
     return data
   }

--- a/src/services/qbit.js
+++ b/src/services/qbit.js
@@ -225,6 +225,28 @@ class Qbit {
     return this.torrentAction('setUploadLimit', hashes, { limit })
   }
 
+  getGlobalDownloadLimit() {
+    return this.axios.get('/transfer/downloadLimit')
+  }
+
+  getGlobalUploadLimit() {
+    return this.axios.get('/transfer/uploadLimit')
+  }
+
+  setGlobalDownloadLimit(limit) {
+    const formData = new FormData()
+    formData.append('limit', limit)
+    
+    return this.axios.post('/transfer/setDownloadLimit', formData)
+  }
+
+  setGlobalUploadLimit(limit) {
+    const formData = new FormData()
+    formData.append('limit', limit)
+
+    return this.axios.post('/transfer/setUploadLimit', formData)
+  }
+
   setShareLimit(hashes, ratioLimit, seedingTimeLimit) {
     return this.torrentAction('setShareLimits', hashes, { ratioLimit, seedingTimeLimit })
   }


### PR DESCRIPTION
# Allowing the control of global speed limits [feat]

First of all, great project and a very clean code. Never used Vue before and I implemented this in less than an hour.
I tried to maximize the reuse in this pr that, as stated in the title, allows users to set global speed limits (both upload and download).
It reuses the SpeedLimitModal component that appears after clicking over the download and upload card speeds in the right drawer of the webpage.

Here is a screencast: https://watch.screencastify.com/v/a09SoF3H2Bt9flO7N1UI
(After settings the global limits you might observe some spikes in the reading of the speed data but the limits are correctly applied)

Closes #339
Enjoy 😃 

UPDATE: 

In a future update, we can also consider adding this stuff inside the settings

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
