### PR TITLE
feat: piece states progress bar

### DIFF
--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -242,6 +242,7 @@ const locale = {
       tabTitleContent: 'Content',
       tabTitleTagsCategories: 'Tags & Categories',
       pageInfo: {
+        pieceStates: 'Progress',
         torrentTitle: 'Torrent title',
         hash: 'hash',
         ratio: 'Ratio',


### PR DESCRIPTION
# feat: piece states progress bar

I (re-)added the original progress indicator with more fitting colors. 
Currently named and placed it based on the original row, but I'm open to suggestions.

## Preview

| Light | Dark |
|---|---|
| ![image](https://user-images.githubusercontent.com/2472626/171060143-22bbd045-b467-48e3-95e3-faaac97b45c9.png) | ![image](https://user-images.githubusercontent.com/2472626/171060154-2e86af9d-c073-485b-a1c4-697dfac18e08.png) |

# PR Checklist
- [X] I've started from master
- [X] I've only committed changes related to this PR
- [X] All Unit tests pass
- [X] I've removed all commented code
- [X] I've removed all unneeded console.log statements
