### PR TITLE
fix: allow native context menu in input elements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="./favicon.ico?s=1">
     <title>qBittorrent</title>
   </head>
-  <body oncontextmenu='return false'>
+  <body>
     <noscript>
       <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,7 @@ export default {
     this.$store.commit('SET_APP_VERSION', process.env['APPLICATION_VERSION'])
     this.$store.commit('SET_LANGUAGE')
     this.checkAuthentication()
+    this.blockContextMenu()
   },
   methods: {
     async checkAuthentication() {
@@ -50,6 +51,20 @@ export default {
 
       this.$store.commit('LOGIN', false)
       if (!this.onLoginPage) return this.$router.push('login')
+    },
+    blockContextMenu() {
+      document.addEventListener('contextmenu', event => {
+        if (!event.target) return
+        const nodeName = event.target.nodeName.toLowerCase()
+        const nodeType = event.target.getAttribute('type')
+
+        if (nodeName === 'textarea') return
+        if (nodeName === 'input' && ['text', 'password', 'email', 'number'].includes(nodeType)) return
+
+        event.preventDefault()
+
+        return false
+      })
     }
   }
 }


### PR DESCRIPTION
# fix: allow native context menu in input elements

This PR improves accessibility for users that copy/paste text (like magnet links & password) with their mouse instead of keyboard shortcuts.

Original implementation: [a83ea144cf1daac09fc76feff5d03347c8ea87ca#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR12](https://github.com/WDaan/VueTorrent/commit/a83ea144cf1daac09fc76feff5d03347c8ea87ca#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR12)

# PR Checklist
- [X] I've started from master
- [X] I've only committed changes related to this PR
- [X] All Unit tests pass
- [X] I've removed all commented code
- [X] I've removed all unneeded console.log statements
