### PR TITLE
fix: Fix category download folder not showing correctly

### DIFF
--- a/src/components/Modals/AddModal.vue
+++ b/src/components/Modals/AddModal.vue
@@ -272,7 +272,7 @@ export default {
     savepath() {
       let savePath = this.getSettings().save_path
       if (this.category) {
-        savePath = this.category.save_path
+        savePath = this.category.savePath
       }
 
       return savePath


### PR DESCRIPTION
# Fix category download folder not showing correctly [fix]

- Simple change to category property so that the category download folder is shown as expected for the respective category.

- Fixes issue #440
    - I don't use Automatic Torrent Managment but I done a test run with it and as long as you have provided a save path manually, it should populate too.

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
