### PR TITLE
fix: renameFile returns 400 error

### DIFF
--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -216,7 +216,7 @@ export default {
       this.togleEditing(item)
     },
     renameFile(item) {
-      qbit.renameFile(this.hash, item.id, item.newName)
+      qbit.renameFile(this.hash, item.name, item.newName)
       item.name = item.newName
       this.togleEditing(item)
     },

--- a/src/services/qbit.js
+++ b/src/services/qbit.js
@@ -349,11 +349,11 @@ class Qbit {
     return this.execute('post', `/torrents/${action}`, params)
   }
 
-  renameFile(hash, id, name) {
+  renameFile(hash, oldPath, newPath) {
     const params = {
       hash,
-      id,
-      name
+      oldPath,
+      newPath
     }
 
     return this.execute('post', '/torrents/renameFile', params)


### PR DESCRIPTION
# renameFile returns 400 error [fix]
In v2.8.0 of the API, qbittorrent changed what parameters are required
for the `/torrents/renameFile` endpoint.  Instead of `hash`, `id`, and `name`,
the params are now `hash`, `oldPath`, and `newPath`.

[Current API spec for renameFile.](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#rename-file)

This fixes [issue 274](https://github.com/WDaan/VueTorrent/issues/274).

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
