### PR TITLE
feat: Links in torrent details view are now clickable

### DIFF
--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -139,25 +139,19 @@
           <td :class="commonStyle">
             {{ $t('modals.detail.pageInfo.trackers') }}
           </td>
-          <td>
-            {{ torrent.tracker }}
-          </td>
+          <td v-html="$options.filters.transformUrlToHref(torrent.tracker)" />
         </tr>
         <tr v-if="createdBy">
           <td :class="commonStyle">
             {{ $t('modals.detail.pageInfo.createdBy') }}
           </td>
-          <td>
-            {{ createdBy }}
-          </td>
+          <td v-html="$options.filters.transformUrlToHref(createdBy)" />
         </tr>
         <tr v-if="comment">
           <td :class="commonStyle">
             {{ $t('torrent.comments') | titleCase }}
           </td>
-          <td>
-            {{ comment }}
-          </td>
+          <td v-html="$options.filters.transformUrlToHref(comment)" />
         </tr>
 
         <tr>

--- a/src/filters.js
+++ b/src/filters.js
@@ -131,3 +131,11 @@ export function limitToValue(value) {
 }
 
 Vue.filter('limitToValue', limitToValue)
+
+export function transformUrlToHref(string) {
+  const expression = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi
+
+  return string.replace(expression, '<a href="$1" target="_blank">$1</a>')
+}
+
+Vue.filter('transformUrlToHref', transformUrlToHref)

--- a/tests/unit/filters.spec.js
+++ b/tests/unit/filters.spec.js
@@ -1,8 +1,28 @@
-import { titleCase } from '../../src/filters'
+import { titleCase, transformUrlToHref } from '../../src/filters'
 
 describe('Filters', () => {
   it('titleCase', () => {
     expect(titleCase('test')).toEqual('Test')
     expect(titleCase('hello there')).toEqual('Hello There')
+  })
+
+  describe('transformUrlToHref()', () => {
+    it('should not transform anything', () => {
+      expect(transformUrlToHref('test')).toEqual('test')
+    })
+
+    it('should transform string where http/https is found', () => {
+      expect(transformUrlToHref('test http://test.something')).toEqual('test <a href="http://test.something" target="_blank">http://test.something</a>')
+      expect(transformUrlToHref('123456 test@345 https://something.else')).toEqual('123456 test@345 <a href="https://something.else" target="_blank">https://something.else</a>')
+    })
+
+    it('should transform string where only www is found', () => {
+      expect(transformUrlToHref('test www.test.something')).toEqual('test <a href="www.test.something" target="_blank">www.test.something</a>')
+    })
+
+    it('should transform string where both www and http/https are found', () => {
+      expect(transformUrlToHref('test http://www.test.something')).toEqual('test <a href="http://www.test.something" target="_blank">http://www.test.something</a>')
+      expect(transformUrlToHref('test https://www.something.else')).toEqual('test <a href="https://www.something.else" target="_blank">https://www.something.else</a>')
+    })
   })
 })


### PR DESCRIPTION
I have added filter to make _"Torrent Details"_ > _"Info"_ links clickable. Filter finds URL and replace it to <a> tag, so it becomes clickable. I have added this feature only to **tracker**, **created by** and **comment** fields, because only those fields can contain URL. This filter **will not** modify URLs which start without www/http/https (i.e. _something.com_) to prevent accidental replacement when sentence ends and new one starts without a space (i.e. _something cool.To replace_)

Also I'm participating in hacktoberfest, so it would help me alot if you can add "hacktoberfest-accepted" label to this PR :)

Related issue: https://github.com/WDaan/VueTorrent/issues/477

Pics:
![Screenshot from 2022-10-03 22-37-48](https://user-images.githubusercontent.com/33595979/193665613-aa6e45fe-d019-4d0a-b5a2-f8254aae1c59.png)

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
