### PR TITLE
fix: Fixed torrent details info table rendering errors after page is refreshed

### DIFF
--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -230,7 +230,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
 import { FullScreenModal } from '@/mixins'
 import qbit from '@/services/qbit'
 
@@ -238,19 +237,14 @@ export default {
   name: 'Info',
   mixins: [FullScreenModal],
   props: {
-    hash: String
+    hash: String,
+    torrent: Object
   },
   data() {
     return {
       commonStyle: 'caption',
       createdBy: null,
       comment: null
-    }
-  },
-  computed: {
-    ...mapGetters(['getTorrent']),
-    torrent() {
-      return this.getTorrent(this.hash)
     }
   },
   mounted() {
@@ -306,7 +300,6 @@ export default {
           ctx.fillRect((data.length - rectWidth), 0, rectWidth, canvas.height)
         }
       }
-
     }
   }
 }
@@ -326,12 +319,16 @@ export default {
   }
 }
 
+:deep(.v-data-table tbody td.caption) {
+  width: 20%;
+}
+
 #pieceStates {
   display: block;
 
   canvas {
     height: 100%;
-    width: 95%;
+    width: 50%;
     border: 1px dotted;
   }
 }

--- a/src/components/TorrentDetail/Tabs/TorrentTagsAndCategories.vue
+++ b/src/components/TorrentDetail/Tabs/TorrentTagsAndCategories.vue
@@ -55,16 +55,14 @@ export default {
   name: 'TorrentTagsAndCategories',
   mixins: [FullScreenModal],
   props: {
-    hash: String
+    hash: String,
+    torrent: Object
   },
   data: () => ({
     categories: []
   }),
   computed: {
-    ...mapGetters(['getTorrent', 'getAvailableTags', 'getCategories']),
-    torrent() {
-      return this.getTorrent(this.hash)
-    },
+    ...mapGetters(['getAvailableTags', 'getCategories']),
     availableTags() {
       return this.getAvailableTags()
     },

--- a/src/views/TorrentDetail.vue
+++ b/src/views/TorrentDetail.vue
@@ -54,7 +54,11 @@
       <v-card-text class="pa-0">
         <v-tabs-items v-model="tab" touchless>
           <v-tab-item eager value="info">
-            <info :is-active="tab === 'info'" :hash="hash" />
+            <info
+              v-if="torrent"
+              :torrent="torrent"
+              :hash="hash"
+            />
           </v-tab-item>
           <v-tab-item eager value="trackers">
             <Trackers :is-active="tab === 'trackers'" :hash="hash" />
@@ -66,7 +70,12 @@
             <Content :is-active="tab === 'content'" :hash="hash" />
           </v-tab-item>
           <v-tab-item eager value="tagsAndCategories">
-            <TagsAndCategories :is-active="tab === 'tagsAndCategories'" :hash="hash" />
+            <TagsAndCategories
+              v-if="torrent"
+              :torrent="torrent"
+              :is-active="tab === 'tagsAndCategories'"
+              :hash="hash"
+            />
           </v-tab-item>
         </v-tabs-items>
       </v-card-text>


### PR DESCRIPTION
I have fixed the issue, where after page refresh in TorrentDetail view, data was not rendered correctly - progress bar was empty. This was because template tried to render data before we can even access it from getTorrent store getter. I have passed torrent as a prop from parent. Actually this is proper way of doing it, so I'm planning to fix other tab items in my next PR, so we will avoid duplicate data fetching when opening these tabs and also will have consistent data on all tab items in TorrentDetail view. Let me know what you think about his :)

Also I have:
- set width for table, so it will not "jump" in width anymore.
- passed 'torrent' prop to TagsAndCategories, because there was an error when refreshing TorrentDetail view, that component couldn't access some properties from torrent - same as main issue exmplained above.

**Please mark this PR as "hacktoberfest-accepted" :)**

I found that his issue is explained here a little bit, so you can check screenshots how it was before:
https://github.com/WDaan/VueTorrent/issues/497

Pic from updated VueTorrent:
![Screenshot from 2022-10-06 21-20-44](https://user-images.githubusercontent.com/33595979/194389395-44c889b7-508d-4328-b87a-7c991b54e8e9.png)

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
