### PR TITLE
fix: refresh torrent detail data from store 

### DIFF
--- a/src/views/TorrentDetail.vue
+++ b/src/views/TorrentDetail.vue
@@ -61,13 +61,22 @@
             />
           </v-tab-item>
           <v-tab-item eager value="trackers">
-            <Trackers :is-active="tab === 'trackers'" :hash="hash" />
+            <Trackers
+              :is-active="tab === 'trackers'"
+              :hash="hash"
+            />
           </v-tab-item>
           <v-tab-item eager value="peers">
-            <Peers :is-active="tab === 'peers'" :hash="hash" />
+            <Peers
+              :is-active="tab === 'peers'"
+              :hash="hash"
+            />
           </v-tab-item>
           <v-tab-item eager value="content">
-            <Content :is-active="tab === 'content'" :hash="hash" />
+            <Content
+              :is-active="tab === 'content'"
+              :hash="hash"
+            />
           </v-tab-item>
           <v-tab-item eager value="tagsAndCategories">
             <TagsAndCategories
@@ -107,6 +116,12 @@ export default {
     hash() {
       return this.$route.params.hash
     }
+  },
+  created() {
+    this.$store.dispatch('INIT_INTERVALS')
+  },
+  destroyed() {
+    this.$store.commit('REMOVE_INTERVALS')
   },
   methods: {
     close() {


### PR DESCRIPTION
**Super small but quality of life feature :)**
After navigating Single torrent > Right click > "Show info" torrent data gets stuck (not being updated anymore). This happens because Dashboard.vue and method which updates torrent data gets destroyed when other view is rendered. I have added dispatch _INIT_INTERVALS()_ method to TorrentDetails.vue _created()_ hook, to update torrent with latest data.

**Please add "hacktoberfest-accepted" to my PR :)**

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
