### PR TITLE
fix: login prompt being displayed when whitelisted

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@ export default {
       if (authenticated) {
         this.$store.commit('LOGIN', true)
         this.$store.commit('updateMainData')
+        if (this.onLoginPage) return this.$router.push('/')
 
         return
       }


### PR DESCRIPTION
# fix login prompt being displayed when whitelisted
This is a very low effort fix for https://github.com/WDaan/VueTorrent/issues/414 & https://github.com/WDaan/VueTorrent/issues/498 though you might see the login prompt for a short moment before it disappears

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
