### PR TITLE
add mention of default username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The sleekest looking WebUI for qBittorrent made with Vue.js!
 - `npm run serve`
 - `npm run lint` (to format the code)
 - `docker-compose up -d` (to start qbittorrent docker => optional, you can edit `vue.config.js` as well)
+- You now may open and access the WebUI under localhost with the default username `admin` and password `adminadmin`.
 
 ## Features
 


### PR DESCRIPTION
# Improve first time contributor experience

I'm a first time contributor and wanted to investigate issue #488 because it seems like a reasonable and nice change to me.
So I cloned the repo and was greeted by a login screen. I didn't know where to lookup the username and password for authenticating in the WebUI. After a quick online search I found out it's the QB default. Since I needed to look this up as first time contributor I think this could help others too not get confused.

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
