### PR TITLE
update torrent-done color to a more readable magenta/pinkish tone

### DIFF
--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -14,7 +14,7 @@ const variables = {
   download: '#64CEAA',
   upload: '#00b3fa',
   // Torrent status colors
-  'torrent-done': '#16573e',
+  'torrent-done': '#9b3184',
   'torrent-downloading': '#5bb974',
   'torrent-fail': '#f83e70',
   'torrent-paused': '#9CA3AF',

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -4,7 +4,7 @@ $secondary: #3e556d;
 $download: #64CEAA;
 $upload: #00b3fa;
 // Torrent status colors
-$torrent-done: #16573e;
+$torrent-done: #9b3184;
 $torrent-downloading: #5bb974;
 $torrent-fail: #f83e70;
 $torrent-paused: #9CA3AF;


### PR DESCRIPTION
# More readable torrent-done color, referencing issue #488 [fix]

I'm not sure if the chosen color is ok with @WDaan so I'm creating a draft first, let me know if you prefer a green color.
I only changed the color but still ran the tests and they passed.


![image](https://user-images.githubusercontent.com/14810858/195988217-93b0b54e-4975-439a-ae38-5234398584ba.png)
![image](https://user-images.githubusercontent.com/14810858/195988791-68e6f6bc-6320-4d31-b747-3024a0dfd0db.png)

Yes, I also updated the SCSS.

fixes #488 

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements