### PR TITLE
feat: add max_ratio_act handling

### DIFF
--- a/src/components/Settings/Tabs/BitTorrent.vue
+++ b/src/components/Settings/Tabs/BitTorrent.vue
@@ -171,11 +171,13 @@
       </v-row>
     </v-list-item>
     <v-list-item>
-      <v-row>
-        <v-col offset="6">
+      <v-row dense>
+        <v-col>
           <v-subheader>
             {{ $t('then') }}
           </v-subheader>
+        </v-col>
+        <v-col>
           <v-select
             v-model="settings.max_ratio_act"
             class="mb-2"

--- a/src/components/Settings/Tabs/BitTorrent.vue
+++ b/src/components/Settings/Tabs/BitTorrent.vue
@@ -175,7 +175,7 @@
       <v-row>
         <v-col>
           <v-select
-            v-model="settings.seeding_limits_then"
+            v-model="settings.max_ratio_act"
             outlined
             :disabled="!settings.max_ratio_enabled && !settings.max_seeding_time_enabled"
             dense
@@ -199,11 +199,11 @@ export default {
     return {
       thenTypes: [
         {
-          value: 1,
+          value: 0,
           text: 'Pause torrent'
         },
         {
-          value: 2,
+          value: 1,
           text: 'Remove torrent'
         },
         {
@@ -211,7 +211,7 @@ export default {
           text: 'Remove torrent and relative files'
         },
         {
-          value: 4,
+          value: 2,
           text: 'Enable torrent super seeding'
         }
       ]

--- a/src/components/Settings/Tabs/BitTorrent.vue
+++ b/src/components/Settings/Tabs/BitTorrent.vue
@@ -170,16 +170,18 @@
         </v-col>
       </v-row>
     </v-list-item>
-    <v-subheader>{{ $t('then') }}</v-subheader>
     <v-list-item>
       <v-row>
-        <v-col>
+        <v-col offset="6">
+          <v-subheader>
+            {{ $t('then') }}
+          </v-subheader>
           <v-select
             v-model="settings.max_ratio_act"
+            class="mb-2"
             outlined
             :disabled="!settings.max_ratio_enabled && !settings.max_seeding_time_enabled"
             dense
-            hide-details
             small-chips
             :items="thenTypes"
           />
@@ -200,19 +202,20 @@ export default {
       thenTypes: [
         {
           value: 0,
-          text: 'Pause torrent'
+          text: this.$i18n.t('modals.settings.pageBittorrent.maxRatioPauseTorrent')
         },
         {
           value: 1,
-          text: 'Remove torrent'
+          text: this.$i18n.t('modals.settings.pageBittorrent.maxRatioRemoveTorrent')
         },
         {
           value: 3,
-          text: 'Remove torrent and relative files'
+          text: this.$i18n.t('modals.settings.pageBittorrent.maxRatioRemoveTorrentAndFiles')
+          
         },
         {
           value: 2,
-          text: 'Enable torrent super seeding'
+          text: this.$i18n.t('modals.settings.pageBittorrent.maxRatioTorrentSuperseeding') 
         }
       ]
     }

--- a/src/components/Settings/Tabs/BitTorrent.vue
+++ b/src/components/Settings/Tabs/BitTorrent.vue
@@ -170,6 +170,22 @@
         </v-col>
       </v-row>
     </v-list-item>
+    <v-subheader>{{ $t('then') }}</v-subheader>
+    <v-list-item>
+      <v-row>
+        <v-col>
+          <v-select
+            v-model="settings.seeding_limits_then"
+            outlined
+            :disabled="!settings.max_ratio_enabled && !settings.max_seeding_time_enabled"
+            dense
+            hide-details
+            small-chips
+            :items="thenTypes"
+          />
+        </v-col>
+      </v-row>
+    </v-list-item>
   </v-card>
 </template>
 
@@ -178,6 +194,28 @@ import { SettingsTab, FullScreenModal } from '@/mixins'
 
 export default {
   name: 'BitTorrent',
-  mixins: [SettingsTab, FullScreenModal]
+  mixins: [SettingsTab, FullScreenModal],
+  data() {
+    return {
+      thenTypes: [
+        {
+          value: 1,
+          text: 'Pause torrent'
+        },
+        {
+          value: 2,
+          text: 'Remove torrent'
+        },
+        {
+          value: 3,
+          text: 'Remove torrent and relative files'
+        },
+        {
+          value: 4,
+          text: 'Enable torrent super seeding'
+        }
+      ]
+    }
+  }
 }
 </script>

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -42,6 +42,7 @@ const locale = {
   magnet: 'Magnet',
   feed: 'feed',
   rule: 'rule',
+  then: 'Then',
 
   /** Torrent */
   torrent: {

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -208,7 +208,11 @@ const locale = {
         torrentInactivityTimer: 'Torrent inactivity timer',
         subHeaderSeedLimits: 'Seed Limits',
         whenRatioReaches: 'When ratio reaches',
-        whenSeedingTimeReaches: 'When seeding time reaches'
+        whenSeedingTimeReaches: 'When seeding time reaches',
+        maxRatioPauseTorrent: 'Pause torrent',
+        maxRatioRemoveTorrent: 'Remove torrent',
+        maxRatioRemoveTorrentAndFiles: 'Remove torrent and files',
+        maxRatioTorrentSuperseeding: 'Enable torrent super seeding'
       },
       pageRss: {
         tabName: {

--- a/tests/unit/BitTorrent.spec.js
+++ b/tests/unit/BitTorrent.spec.js
@@ -4,118 +4,133 @@ import BitTorrent from '../../src/components/Settings/Tabs/BitTorrent.vue'
 let wrapper
 
 const getSettingsMockRes = {
-    dht:true,
-    pex:true,
-    lsd:true,
-    anonymous_mode:true,
-    queueing_enabled:true,
-    max_active_downloads:1,
-    max_active_uploads:'max_active_uploads',
-    max_active_torrents:6,
-    dont_count_slow_torrents:true,
-    slow_torrent_dl_rate_threshold:1,
-    slow_torrent_ul_rate_threshold:1,
-    slow_torrent_inactive_timer:1,
-    max_ratio_enabled:true,
-    max_ratio:1,
-    max_seeding_time_enabled:true,
-    max_seeding_time:1
+  dht: true,
+  pex: true,
+  lsd: true,
+  anonymous_mode: true,
+  queueing_enabled: true,
+  max_active_downloads: 1,
+  max_active_uploads: 'max_active_uploads',
+  max_active_torrents: 6,
+  dont_count_slow_torrents: true,
+  slow_torrent_dl_rate_threshold: 1,
+  slow_torrent_ul_rate_threshold: 1,
+  slow_torrent_inactive_timer: 1,
+  max_ratio_enabled: true,
+  max_ratio: 1,
+  max_seeding_time_enabled: true,
+  max_seeding_time: 1
 }
 
-const getCustomWrapper = (getSettingsRes)=>  {
-    return shallowMount(BitTorrent,{ mocks: { $t: (x) => x , $store: {
-        getters:{getSettings:()=>{
-            return getSettingsRes
-        }},
-        state: {  }
-            }
-        } })
+const getCustomWrapper = getSettingsRes => {
+  return shallowMount(BitTorrent, { 
+    mocks: { 
+      $i18n: {
+        t: x => x
+      },
+      $t: x => x,
+      $store: {
+        getters: { getSettings: () => {
+          return getSettingsRes
+        } },
+        state: { }
+      }
+    }
+
+  })
 }
 
 describe('BitTorrent', () => {
-    beforeEach(() => {
-        wrapper = shallowMount(BitTorrent,{ mocks: { $t: (x) => x , $store: {
-            getters:{getSettings:()=>{
-                return getSettingsMockRes
-            }},
-            state: {  }
-                }
-            } })
+  beforeEach(() => {
+    wrapper = shallowMount(BitTorrent, { 
+      mocks: {
+        $i18n: {
+          t: x => x
+        },
+        $t: x => x, 
+        $store: {
+          getters: { getSettings: () => {
+            return getSettingsMockRes
+          } },
+          state: { }
+        }
+      }
     })
+  })
 
-    it('render correctly', () => {
-        expect(wrapper.html()).toMatchSnapshot()
-    })
+  it('render correctly', () => {
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when anonymous_mode is false', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            anonymous_mode:false
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when anonymous_mode is false', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      anonymous_mode: false
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when queueing_enabled is false', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            queueing_enabled:false
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when queueing_enabled is false', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      queueing_enabled: false
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when dont_count_slow_torrents is false', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            dont_count_slow_torrents:false
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when dont_count_slow_torrents is false', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      dont_count_slow_torrents: false
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when max_ratio_enabled is false', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            max_ratio_enabled:false
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when max_ratio_enabled is false', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      max_ratio_enabled: false
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when max_seeding_time_enabled is false', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            max_seeding_time_enabled:false
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when max_seeding_time_enabled is false', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      max_seeding_time_enabled: false
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when max_active_downloads is 2', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            max_active_downloads:2
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when max_active_downloads is 2', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      max_active_downloads: 2
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when max_active_torrents is 3', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            max_active_torrents:3
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when max_active_torrents is 3', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      max_active_torrents: 3
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when slow_torrent_dl_rate_threshold is 25', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            slow_torrent_dl_rate_threshold:25
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when slow_torrent_dl_rate_threshold is 25', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      slow_torrent_dl_rate_threshold: 25
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 
-    it('render correctly when slow_torrent_ul_rate_threshold is 24', () => {
-        const customerWarpper = getCustomWrapper({
-            ...getSettingsMockRes,
-            slow_torrent_ul_rate_threshold:24
-        })
-        expect(customerWarpper.html()).toMatchSnapshot()
+  it('render correctly when slow_torrent_ul_rate_threshold is 24', () => {
+    const customWrapper = getCustomWrapper({
+      ...getSettingsMockRes,
+      slow_torrent_ul_rate_threshold: 24
     })
+    expect(customWrapper.html()).toMatchSnapshot()
+  })
 })

--- a/tests/unit/__snapshots__/BitTorrent.spec.js.snap
+++ b/tests/unit/__snapshots__/BitTorrent.spec.js.snap
@@ -62,6 +62,14 @@ exports[`BitTorrent render correctly 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
 </v-card-stub>
 `;
 
@@ -124,6 +132,14 @@ exports[`BitTorrent render correctly when anonymous_mode is false 1`] = `
       </v-col-stub>
       <v-col-stub tag="div">
         <v-text-field-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="1" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="number" class="mb-2"></v-text-field-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -192,6 +208,14 @@ exports[`BitTorrent render correctly when dont_count_slow_torrents is false 1`] 
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
 </v-card-stub>
 `;
 
@@ -254,6 +278,14 @@ exports[`BitTorrent render correctly when max_active_downloads is 2 1`] = `
       </v-col-stub>
       <v-col-stub tag="div">
         <v-text-field-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="1" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="number" class="mb-2"></v-text-field-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -322,6 +354,14 @@ exports[`BitTorrent render correctly when max_active_torrents is 3 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
 </v-card-stub>
 `;
 
@@ -384,6 +424,14 @@ exports[`BitTorrent render correctly when max_ratio_enabled is false 1`] = `
       </v-col-stub>
       <v-col-stub tag="div">
         <v-text-field-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="1" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="number" class="mb-2"></v-text-field-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -452,6 +500,14 @@ exports[`BitTorrent render correctly when max_seeding_time_enabled is false 1`] 
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
 </v-card-stub>
 `;
 
@@ -514,6 +570,14 @@ exports[`BitTorrent render correctly when queueing_enabled is false 1`] = `
       </v-col-stub>
       <v-col-stub tag="div">
         <v-text-field-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="1" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="number" class="mb-2"></v-text-field-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -582,6 +646,14 @@ exports[`BitTorrent render correctly when slow_torrent_dl_rate_threshold is 25 1
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
 </v-card-stub>
 `;
 
@@ -644,6 +716,14 @@ exports[`BitTorrent render correctly when slow_torrent_ul_rate_threshold is 24 1
       </v-col-stub>
       <v-col-stub tag="div">
         <v-text-field-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="1" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="number" class="mb-2"></v-text-field-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
+  <v-subheader-stub>then</v-subheader-stub>
+  <v-list-item-stub activeclass="" tag="div">
+    <v-row-stub tag="div">
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>

--- a/tests/unit/__snapshots__/BitTorrent.spec.js.snap
+++ b/tests/unit/__snapshots__/BitTorrent.spec.js.snap
@@ -62,11 +62,15 @@ exports[`BitTorrent render correctly 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -135,11 +139,15 @@ exports[`BitTorrent render correctly when anonymous_mode is false 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -208,11 +216,15 @@ exports[`BitTorrent render correctly when dont_count_slow_torrents is false 1`] 
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -281,11 +293,15 @@ exports[`BitTorrent render correctly when max_active_downloads is 2 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -354,11 +370,15 @@ exports[`BitTorrent render correctly when max_active_torrents is 3 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -427,11 +447,15 @@ exports[`BitTorrent render correctly when max_ratio_enabled is false 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -500,11 +524,15 @@ exports[`BitTorrent render correctly when max_seeding_time_enabled is false 1`] 
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -573,11 +601,15 @@ exports[`BitTorrent render correctly when queueing_enabled is false 1`] = `
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -646,11 +678,15 @@ exports[`BitTorrent render correctly when slow_torrent_dl_rate_threshold is 25 1
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
@@ -719,11 +755,15 @@ exports[`BitTorrent render correctly when slow_torrent_ul_rate_threshold is 24 1
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>
-  <v-subheader-stub>then</v-subheader-stub>
   <v-list-item-stub activeclass="" tag="div">
-    <v-row-stub tag="div">
+    <v-row-stub tag="div" dense="true">
       <v-col-stub tag="div">
-        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" hidedetails="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true"></v-select-stub>
+        <v-subheader-stub>
+          then
+        </v-subheader-stub>
+      </v-col-stub>
+      <v-col-stub tag="div">
+        <v-select-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="$dropdown" backgroundcolor="" dense="true" loaderheight="2" clearicon="$clear" outlined="true" type="text" valuecomparator="[Function]" nodatatext="$vuetify.noDataText" items="[object Object],[object Object],[object Object],[object Object]" itemcolor="primary" itemdisabled="disabled" itemtext="text" itemvalue="value" menuprops="[object Object]" smallchips="true" class="mb-2"></v-select-stub>
       </v-col-stub>
     </v-row-stub>
   </v-list-item-stub>


### PR DESCRIPTION
# feat: add max_ratio_act handling

Implements #483 

![image](https://user-images.githubusercontent.com/9303791/196760708-2dc08822-48ea-404f-9bde-4c3c1e1f572b.png)

Wanted to open this as a draft since it's almost finished but also because I had to reverse engineer the thing a little bit here because [the following documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-application-preferences) doesn't show correctly all the possible values assignable to the max_ratio_act param.

I've inspected it from the graphical qbittorrent instance running on my mac that the values are indeed four and go from 0 to 3 and the order is a bit fucked up. Look at this screen I've made that maps the index of the options within the select to the actual values:

![image](https://user-images.githubusercontent.com/9303791/196762501-76932b6c-b118-4ccd-8cb2-ec85aae3f11c.png)


# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
