### PR TITLE
feat: render "active time" in torrent info tab

### DIFF
--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -46,6 +46,15 @@
         </tr>
         <tr>
           <td :class="commonStyle">
+            {{ $t("torrent.timeActive") | titleCase }}
+          </td>
+          <td>
+            {{ torrent.time_active }}
+            <span v-if="torrent.seeding_time">{{ `(${$t("torrent.seededFor")} ${torrent.seeding_time})` }}</span>
+          </td>
+        </tr>
+        <tr>
+          <td :class="commonStyle">
             {{ $t('torrent.downloaded') | titleCase }}
           </td>
           <td>

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -57,7 +57,9 @@ const locale = {
     created: 'created by',
     comments: 'comments',
     uploadedSession: 'Uploaded Session',
-    torrentTitle: 'Torrent Title'
+    torrentTitle: 'Torrent Title',
+    timeActive: 'Time Active',
+    seededFor: 'seeded for'
   },
   /** Navbar */
   navbar: {

--- a/src/models/Torrent.js
+++ b/src/models/Torrent.js
@@ -1,3 +1,8 @@
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
+dayjs.extend(duration)
+
 export default class Torrent {
   constructor(data) {
     this.name = data.name
@@ -32,6 +37,8 @@ export default class Torrent {
     this.availability = Math.round(data.availability * 100) / 100
     this.forced = data.state.includes('forced')
     this.magnet = data.magnet_uri
+    this.time_active = dayjs.duration(data.time_active, 'seconds').format('D[d] H[h] m[m] s[s]')
+    this.seeding_time = data.seeding_time > 0 ? dayjs.duration(data.seeding_time, 'seconds').format('D[d] H[h] m[m] s[s]') : null
 
     Object.freeze(this)
   }


### PR DESCRIPTION
# My Title [feat/fix/perf/chore]
This PR adds an extra row to the "info" torrent details tab to render "time active".

I used `dayjs` for formatting durations, which isn't ideal, as there's no way to skip zero values, but it works and is a good starting point.

I used the original QBit Web UI as a reference for the "time active" column and made it contain "seeding time" as well if it's greater than 0.

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
