### PR TITLE
perf: debounce torrent search field

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -142,6 +142,7 @@
 </template>
 
 <script>
+import _ from 'lodash'
 import { mapState, mapGetters } from 'vuex'
 import { mdiTextBoxSearch, mdiChevronLeftCircle, mdiMagnify, mdiCheckboxMarked, mdiCheckboxBlankOutline, mdiSort, mdiArrowUpThin, mdiArrowDownThin } from '@mdi/js'
 import { QuickScore } from 'quick-score'
@@ -225,9 +226,9 @@ export default {
       get() {
         return this.dashboard.searchFilter
       },
-      set(val) {
+      set: _.debounce(function (val) {
         this.dashboard.searchFilter = val
-      }
+      }, 300)
     },
     topPagination() {
       return this.getWebuiSettings().topPagination


### PR DESCRIPTION
# Debounce Torrent search field [chore]

This PR debounces the Torrent search field in order to improve the responsiveness of the UI while typing.

It appears that searching is a pretty costly operation, which causes the entire tab to freeze when searching through lots of torrents, and debouncing it makes it smoother.

(Partially) addresses #540, additional work still needed to see if searching can be made faster/asynchronous at least.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
