### PR TITLE
fix: proper unit for up/dl speed in details

### DIFF
--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -85,7 +85,7 @@
           </td>
           <td>
             {{ torrent.dlspeed | getDataValue }}
-            {{ torrent.dlspeed | getDataUnit(1) }}
+            {{ torrent.dlspeed | getDataUnit(1) }}/s
           </td>
         </tr>
         <tr>
@@ -94,7 +94,7 @@
           </td>
           <td>
             {{ torrent.upspeed | getDataValue }}
-            {{ torrent.upspeed | getDataUnit(1) }}
+            {{ torrent.upspeed | getDataUnit(1) }}/s
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
# Proper unit for Upload/Download Speed in Details [fix]

This PR adds a `/s` suffix to the unit of the upload and download speed in the Torrent Details view.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
