### PR TITLE
fix: proper unit for up/dl speed in graph

### DIFF
--- a/src/components/Navbar/SpeedGraph.vue
+++ b/src/components/Navbar/SpeedGraph.vue
@@ -57,7 +57,7 @@ export default {
           },
           y: {
             formatter: value => {
-              return `${getDataValue(value, 0)} ${getDataUnit(value)}`
+              return `${getDataValue(value, 0)} ${getDataUnit(value)}/s`
             }
           }
         }


### PR DESCRIPTION
# Proper unit for Upload/Download Speed in Graph [fix]

This PR adds a `/s` suffix to the unit of the upload and download speed in the Graph navbar component.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
