### PR TITLE
fix: Unable to rename torrent

### DIFF
--- a/src/services/qbit.ts
+++ b/src/services/qbit.ts
@@ -125,12 +125,7 @@ export class QBitApi {
   }
 
   setTorrentName(hash, name) {
-    const params = {
-      hash,
-      name
-    }
-
-    return this.axios.get('/torrents/rename', { params })
+    return this.execute('post', '/torrents/rename', { hash, name })
   }
 
   getTorrentPieceStates(hash) {


### PR DESCRIPTION
# Unable to rename torrent [fix]

This PR fixes the `qbit.setTorrentName` using `GET` method instead of `POST`.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
