### PR TITLE
Fix default change location not prefilling

### DIFF
--- a/src/components/Modals/ChangeLocationModal.vue
+++ b/src/components/Modals/ChangeLocationModal.vue
@@ -13,7 +13,9 @@
               <v-list flat class="mb-4">
                 <v-list-item v-for="t in torrents" :key="t.hash" else>
                   <v-list-item-content>
-                    <v-list-item-title class="text-wrap" v-text="t.name" />
+                    <v-list-item-title class="text-wrap">
+                      {{ t.name }}
+                    </v-list-item-title>
                   </v-list-item-content>
                 </v-list-item>
               </v-list>
@@ -68,7 +70,7 @@ export default {
     }
   },
   created() {
-    this.newPath = this.getSettings().save_path
+    this.newPath = this.torrents[0].savePath
   },
   methods: {
     setLocation() {


### PR DESCRIPTION
# Default change location not prefilling [fix]

Fixes change location not prefilling by using the first torrent savePath instead of using the settings' savePath.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #581