### PR TITLE
Add toast when renameFile and renameFolder failed

### DIFF
--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -65,6 +65,7 @@ import qbit from '@/services/qbit'
 import { treeify } from '@/helpers'
 import { FullScreenModal } from '@/mixins'
 import { mdiClose, mdiContentSave, mdiPencil, mdiFolderOpen, mdiFolder, mdiFile, mdiTrendingUp, mdiPriorityHigh, mdiArrowUp, mdiArrowDown, mdiPriorityLow } from '@mdi/js'
+import Vue from "vue";
 
 const FILE_PRIORITY_OPTIONS = [
   { name: 'max', icon: mdiPriorityHigh, value: 7 },
@@ -177,11 +178,15 @@ export default {
     },
     renameFile(item) {
       qbit.renameFile(this.hash, item.name, item.newName)
+          .catch(() => Vue.$toast.error(this.$t('toast.renameFileFailed')))
+
       item.name = item.newName
       this.toggleEditing(item)
     },
     renameFolder(item) {
       qbit.renameFolder(this.hash, item.name, item.newName)
+          .catch(() => Vue.$toast.error(this.$t('toast.renameFolderFailed')))
+
       item.name = item.newName
       this.toggleEditing(item)
     },

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -453,7 +453,9 @@ const locale = {
     settingsSaved: 'Settings saved successfully!',
     categorySaved: 'Category edited successfully!',
     feedSaved: 'Feed saved successfully!',
-    ruleSaved: 'Rule saved!'
+    ruleSaved: 'Rule saved!',
+    renameFileFailed: 'Unable to rename file',
+    renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -450,7 +450,9 @@ const locale = {
     settingsSaved: '¡Los ajustes se guardaron correctamente!',
     categorySaved: '¡Categoría guardada correctamente!'
     // feedSaved: 'Feed saved successfully!',
-    // ruleSaved: 'Rule saved!'
+    // ruleSaved: 'Rule saved!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Paramètres enregistrés avec succès!',
     categorySaved: 'Catégorie modifiée avec succès!',
     feedSaved: 'Flux enregistré !',
-    ruleSaved: 'Règle enregistrée !'
+    ruleSaved: 'Règle enregistrée !',
+    renameFileFailed: 'Impossible de renommer le fichier',
+    renameFolderFailed: 'Impossible de renommer le dossier'
   },
 
   /** RightClick **/

--- a/src/lang/id.js
+++ b/src/lang/id.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Pengaturan sukses disimpan!',
     categorySaved: 'Kategori sukses diubah!',
     feedSaved: 'Feed berhasil disimpan!',
-    ruleSaved: 'Rule disimpan!'
+    ruleSaved: 'Rule disimpan!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/it.js
+++ b/src/lang/it.js
@@ -449,7 +449,9 @@ const locale = {
     // settingsSaved: 'Settings saved successfully!',
     // categorySaved: 'Category edited successfully!',
     // feedSaved: 'Feed saved successfully!',
-    // ruleSaved: 'Rule saved!'
+    // ruleSaved: 'Rule saved!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -448,7 +448,9 @@ const locale = {
     settingsSaved: '設定の保存に成功しました!',
     categorySaved: 'カテゴリーの編集に成功しました!',
     feedSaved: 'フィードの編集に成功しました!',
-    ruleSaved: 'ルールの編集に成功しました!'
+    ruleSaved: 'ルールの編集に成功しました!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Instellingen successvol opgeslagen!',
     categorySaved: 'Categorie successvol opgeslagen!'
     // feedSaved: 'Feed saved successfully!',
-    // ruleSaved: 'Rule saved!'
+    // ruleSaved: 'Rule saved!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/pt-br.js
+++ b/src/lang/pt-br.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Configurações salvas com Sucesso!',
     categorySaved: 'Categoria Editada com Sucesso!'
     // feedSaved: 'Feed saved successfully!',
-    // ruleSaved: 'Rule saved!'
+    // ruleSaved: 'Rule saved!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/ru.js
+++ b/src/lang/ru.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Настройки успешно сохранены!',
     categorySaved: 'Категория успешно отредактирована!',
     feedSaved: 'Канал успешно сохранен!',
-    ruleSaved: 'Правила сохранены!'
+    ruleSaved: 'Правила сохранены!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/ua.js
+++ b/src/lang/ua.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Налаштування успішно збережено!',
     categorySaved: 'Категорія успішно відредагована!',
     feedSaved: 'Стрічка збережена успішно!',
-    ruleSaved: 'Правило збережено!'
+    ruleSaved: 'Правило збережено!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/vi.js
+++ b/src/lang/vi.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: 'Cài đặt đã lưu thành công!',
     categorySaved: 'Thể loại đã chỉnh sửa thành công!'
     // feedSaved: 'Feed saved successfully!',
-    // ruleSaved: 'Rule saved!'
+    // ruleSaved: 'Rule saved!',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/zh-hans.js
+++ b/src/lang/zh-hans.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: '设置保存成功！',
     categorySaved: '分类编辑成功！',
     feedSaved: '订阅源保存成功！',
-    ruleSaved: '规则保存成功！'
+    ruleSaved: '规则保存成功！',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/

--- a/src/lang/zh-hant.js
+++ b/src/lang/zh-hant.js
@@ -449,7 +449,9 @@ const locale = {
     settingsSaved: '設定儲存成功！',
     categorySaved: '分類編輯成功！',
     feedSaved: '訂閱源儲存成功！',
-    ruleSaved: '規則保存成功！'
+    ruleSaved: '規則保存成功！',
+    // renameFileFailed: 'Unable to rename file',
+    // renameFolderFailed: 'Unable to rename file'
   },
 
   /** RightClick **/


### PR DESCRIPTION
# Add toast when renameFile and renameFolder failed [feat]

Adds a toast to notify the user that the file / folder can't be renamed instead of silently ignoring it (VueTorrent still renames it in "local" though)

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
