### PR TITLE
Reset pageNumber when changing filters to prevent value overflow

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -274,7 +274,7 @@ export default {
 
       const pageCount = Math.ceil( torrents.length / this.paginationSize);
       if (pageCount < this.pageNumber) {
-        this.pageNumber = pageCount
+        this.pageNumber = Math.max(1, pageCount)
       }
     }
   },

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -271,6 +271,11 @@ export default {
   watch: {
     torrents: function (torrents) {
       this.$store.commit('SET_CURRENT_ITEM_COUNT', torrents.length)
+
+      const pageCount = Math.ceil( torrents.length / this.paginationSize);
+      if (pageCount < this.pageNumber) {
+        this.pageNumber = pageCount
+      }
     }
   },
   mounted() {


### PR DESCRIPTION
# Reset pageNumber when changing filters to prevent value overflow [perf]

Checks if the current page number is exceeding the total page count, and sets it to the last page if it's the case to prevent the dashboard from displaying an empty list of torrents.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #344