### PR TITLE
chore: Update Traditional Chinese translation

### DIFF
--- a/src/lang/zh-hant.js
+++ b/src/lang/zh-hant.js
@@ -44,6 +44,7 @@ const locale = {
   feed: '訂閱源',
   rule: '規則',
   then: '然後',
+  of: 'of',
 
   /** Dashboard */
   dashboard: {
@@ -102,7 +103,8 @@ const locale = {
       altSpeed: '替補速率限制',
       dark: '暗色介面',
       light: '亮色介面'
-    }
+    },
+    torrentsCount: 'No torrents | {n} torrent | {n} torrents'
   },
 
   /** Modals */
@@ -231,7 +233,9 @@ const locale = {
           supportParamC: '%C: 檔案數',
           supportParamZ: '%Z: 種子大小 (位元組 byte)',
           supportParamT: '%T: 當前的追蹤者',
-          supportParamI: '%I: 資訊雜湊值'
+          supportParamI: '%I: 資訊雜湊值 v1',
+          supportParamJ: '%J: 資訊雜湊值 v2',
+          supportParamK: '%K: 種子 ID'
         }
       },
       pageConnection: {


### PR DESCRIPTION
# Update Traditional Chinese translations [chore]

I leave line 47 and 107 to be untouched since I can't find a good way to translate line 47 into Chinese and line 107 is related to line 47.

Detail:
In Chinese, the position of the numbers of "A of B" (e.g. 2 of 10) should be switched to become "B 中的 A" (e.g. 10 中的 2). It is beyond my ability so I leave it untouched for now.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
