### PR TITLE
Fix "409 Conflict" on file/folder rename

### DIFF
--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -178,8 +178,16 @@ export default {
     },
     renameFile(item) {
       const lastPathSep = item.fullName.lastIndexOf("/")
-      const prefix = item.fullName.substring(0, lastPathSep)
-      qbit.renameFile(this.hash, `${prefix}/${item.name}`, `${prefix}/${item.newName}`)
+      const args = [this.hash]
+
+      if (lastPathSep === -1)
+        args.push(item.name, item.newName)
+      else {
+        const prefix = item.fullName.substring(0, lastPathSep)
+        args.push(`${prefix}/${item.name}`, `${prefix}/${item.newName}`)
+      }
+
+      qbit.renameFile(...args)
           .catch(() => Vue.$toast.error(this.$t('toast.renameFileFailed')))
 
       item.name = item.newName
@@ -187,8 +195,16 @@ export default {
     },
     renameFolder(item) {
       const lastPathSep = item.fullName.lastIndexOf("/")
-      const prefix = item.fullName.substring(0, lastPathSep)
-      qbit.renameFolder(this.hash, `${prefix}/${item.name}`, `${prefix}/${item.newName}`)
+      const args = [this.hash]
+
+      if (lastPathSep === -1)
+        args.push(item.name, item.newName)
+      else {
+        const prefix = item.fullName.substring(0, lastPathSep)
+        args.push(`${prefix}/${item.name}`, `${prefix}/${item.newName}`)
+      }
+
+      qbit.renameFolder(...args)
           .catch(() => Vue.$toast.error(this.$t('toast.renameFolderFailed')))
 
       item.name = item.newName

--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -177,7 +177,9 @@ export default {
       this.toggleEditing(item)
     },
     renameFile(item) {
-      qbit.renameFile(this.hash, item.name, item.newName)
+      const lastPathSep = item.fullName.lastIndexOf("/")
+      const prefix = item.fullName.substring(0, lastPathSep)
+      qbit.renameFile(this.hash, `${prefix}/${item.name}`, `${prefix}/${item.newName}`)
           .catch(() => Vue.$toast.error(this.$t('toast.renameFileFailed')))
 
       item.name = item.newName

--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -186,7 +186,9 @@ export default {
       this.toggleEditing(item)
     },
     renameFolder(item) {
-      qbit.renameFolder(this.hash, item.name, item.newName)
+      const lastPathSep = item.fullName.lastIndexOf("/")
+      const prefix = item.fullName.substring(0, lastPathSep)
+      qbit.renameFolder(this.hash, `${prefix}/${item.name}`, `${prefix}/${item.newName}`)
           .catch(() => Vue.$toast.error(this.$t('toast.renameFolderFailed')))
 
       item.name = item.newName

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,7 @@
 import { isProduction } from './utils'
 
 export function formatBytes(a, b) {
-  if (a == 0) return '0 B'
+  if (a === 0) return '0 B'
   const c = 1024
   const d = b || 2
   const e = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
@@ -69,10 +69,10 @@ export function treeify(paths) {
   // parse folders
   result = result.map(el => parseFolder(el))
 
-  function parseFolder(el) {
+  function parseFolder(el, parent) {
     if (el.children.length !== 0) {
-      const folder = createFolder(el.name, el.children)
-      folder.children = folder.children.map(el => parseFolder(el))
+      const folder = createFolder(parent, el.name, el.children)
+      folder.children = folder.children.map(child => parseFolder(child, folder))
 
       return folder
     }
@@ -96,10 +96,10 @@ function createFile(data, name, children) {
   }
 }
 
-function createFolder(name, children) {
+function createFolder(parent, name, children) {
   return {
     name: name,
-    fullName: name,
+    fullName: parent === undefined ? name : `${parent.fullName}/${name}`,
     type: 'directory',
     children: children
   }


### PR DESCRIPTION
# Fix "409 Conflict" on file/folder rename [fix]

This PR fixes the 409 errors we received when trying to rename files and folders at least 1 level deep in the filetree.

Rework of the folder object construction in the local filetree and use of the fullPath attribute to include base path in the request.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
