### PR TITLE
Fix dashboard items settings not saving

### DIFF
--- a/src/components/Settings/Tabs/VueTorrent/Dashboard.vue
+++ b/src/components/Settings/Tabs/VueTorrent/Dashboard.vue
@@ -95,7 +95,8 @@ export default {
         CompletedOn: i18n.t(`${localePrefix}.completion_on`)
       }
 
-      return properties.map(property => ({ ...property, label: localeMap[property.name] }))
+      properties.forEach(property => property.label = localeMap[property.name])
+      return properties
     }
   }
 }


### PR DESCRIPTION
# Fix dashboard items settings not saving [fix]

This PR fixes dashboard items not using $store.state reference, hence not saving changes in the UI.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
