### PR TITLE
perf: Disable hide condition on page scroll

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -294,12 +294,6 @@ export default {
     document.addEventListener('dragenter', this.detectDragEnter)
     this.$store.state.selectMode = false
     window.scrollTo(0, 0)
-    document.addEventListener(
-      'scroll',
-      function () {
-        this.trcMenu.show = false
-      }.bind(this)
-    )
   },
   created() {
     this.$store.dispatch('INIT_INTERVALS')


### PR DESCRIPTION
# Disable hide condition on page scroll [perf]

Disabled hide condition on page scroll which prevented seeing the whole menu while using the WebUI on mobile with landscape orientation

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
