### PR TITLE
fix: Duplicate reference in dashboard settings

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -97,8 +97,8 @@ export default new Vuex.Store({
       paginationSize: 15,
       dateFormat: 'DD/MM/YYYY, HH:mm:ss',
       openSideBarOnStart: true,
-      busyTorrentProperties: [...propertiesTemplate],
-      doneTorrentProperties: [...propertiesTemplate]
+      busyTorrentProperties: JSON.parse(JSON.stringify(propertiesTemplate)),
+      doneTorrentProperties: JSON.parse(JSON.stringify(propertiesTemplate))
     },
     categories: [],
     trackers: [],


### PR DESCRIPTION
# Duplicate reference in dashboard settings [fix]

Fix issue by duplicating properties template using JSON de-/serialization

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #610 