### PR TITLE
fix: Invalid deconstruct on qbit service

### DIFF
--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -137,7 +137,7 @@ export default {
       })
     },
     async getTorrentFiles() {
-      const { data } = await qbit.getTorrentFiles(this.hash)
+      const data = await qbit.getTorrentFiles(this.hash)
       data.forEach((d, i) => {
         d.id = i
         d.name = d.name.replace('.unwanted/', '')

--- a/src/components/TorrentDetail/Tabs/DetailPeers.vue
+++ b/src/components/TorrentDetail/Tabs/DetailPeers.vue
@@ -129,7 +129,7 @@ export default {
       return isWindows()
     },
     async getTorrentPeers() {
-      const { data } = await qbit.getTorrentPeers(this.hash, this.rid + 1 || undefined)
+      const data = await qbit.getTorrentPeers(this.hash, this.rid + 1 || undefined)
 
       this.rid = data.rid
 

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -145,7 +145,7 @@
           </td>
           <td>
             <span v-for="trackersPart in splitString(torrent.tracker)" :key="trackersPart">
-              <a v-if="stringContainsUrl(trackersPart)" _target="blank" :href="trackersPart">{{ trackersPart }}</a>
+              <a v-if="stringContainsUrl(trackersPart)" target="_blank" :href="trackersPart">{{ trackersPart }}</a>
               <span v-else>{{ trackersPart }}</span>
             </span>
           </td>
@@ -156,7 +156,7 @@
           </td>
           <td>
             <span v-for="createdByPart in splitString(createdBy)" :key="createdByPart">
-              <a v-if="stringContainsUrl(createdByPart)" _target="blank" :href="createdByPart">{{ createdByPart }}</a>
+              <a v-if="stringContainsUrl(createdByPart)" target="_blank" :href="createdByPart">{{ createdByPart }}</a>
               <span v-else>{{ createdByPart }}</span>
             </span>
           </td>
@@ -167,7 +167,7 @@
           </td>
           <td>
             <span v-for="commentPart in splitString(comment)" :key="commentPart">
-              <a v-if="stringContainsUrl(commentPart)" _target="blank" :href="commentPart">{{ commentPart }}</a>
+              <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
               <span v-else>{{ commentPart }}</span>
             </span>
           </td>
@@ -272,8 +272,8 @@ export default {
     async renderTorrentPieceStates() {
       const canvas = document.querySelector('#pieceStates canvas')
 
-      const { data: files } = await qbit.getTorrentFiles(this.hash)
-      const { data: pieces } = await qbit.getTorrentPieceStates(this.hash)
+      const files = await qbit.getTorrentFiles(this.hash)
+      const pieces = await qbit.getTorrentPieceStates(this.hash)
 
       // Source: https://github.com/qbittorrent/qBittorrent/blob/6229b817300344759139d2fedbd59651065a561d/src/webui/www/private/scripts/prop-general.js#L230
       if (pieces) {

--- a/src/components/TorrentDetail/Tabs/Trackers.vue
+++ b/src/components/TorrentDetail/Tabs/Trackers.vue
@@ -104,13 +104,12 @@ export default {
   },
   methods: {
     async getTorrentTrackers() {
-      const { data } = await qbit.getTorrentTrackers(this.hash)
-      this.tempTrackers = data
+      this.tempTrackers = await qbit.getTorrentTrackers(this.hash)
     },
     async addTrackers() {
       if (!this.newTrackers.length) return (this.trackerDialog = false)
 
-      qbit.addTorrentTrackers(this.hash, this.newTrackers)
+      await qbit.addTorrentTrackers(this.hash, this.newTrackers)
       this.newTrackers = ''
       await this.getTorrentTrackers()
       this.trackerDialog = false


### PR DESCRIPTION
# Invalid deconstruct on qbit service [fix]

Forgot some deconstructors in the TS migration of the qbit service

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
