### PR TITLE
fix: change rss-unread color from white to #ccc

### DIFF
--- a/src/views/RssArticles.vue
+++ b/src/views/RssArticles.vue
@@ -141,7 +141,7 @@ export default defineComponent({
 
 <style>
 .rss-unread {
-  color: white;
+  color: #ccc;
 }
 .rss-read {
   color: grey;


### PR DESCRIPTION
# [fix](fix: change rss-unread color from white to #ccc)

In light mode, the `white` rss unread item is completely invisible. After changing to `#ccc` color, you can clearly distinguish between read and unread

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
