### PR TITLE
fix zeroing

### DIFF
--- a/src/models/Status.ts
+++ b/src/models/Status.ts
@@ -17,11 +17,18 @@ export default class Status {
   upspeedRaw: number = 0
 
   constructor(in_state?: Optional<ServerState>) {
+    const previous = store.state.status
+
     if (!in_state) {
+      this.alltimeDownloaded = previous.alltimeDownloaded
+      this.alltimeUploaded = previous.alltimeUploaded
+      this.freeDiskSpace = previous.freeDiskSpace
+      this.sessionDownloaded = previous.sessionDownloaded
+      this.sessionUploaded = previous.sessionUploaded
+      
+      Object.freeze(this)
       return
     }
-
-    const previous = store.state.status
 
     this.alltimeDownloaded = in_state.alltime_dl || previous.alltimeDownloaded
     this.alltimeUploaded = in_state.alltime_ul || previous.alltimeUploaded


### PR DESCRIPTION
# My Title [feat/fix/perf/chore]

Stop all-time & session & disk-free data from zero-ing when 
`response.server_state` is sometimes null (for some reason)

# PR Checklist

- [ ] I've started from master
- [ ] I've only committed changes related to this PR
- [ ] All Unit tests pass
- [ ] I've removed all commented code
- [ ] I've removed all unneeded console.log statements
