### PR TITLE
perf: Disable category selection in TRC menu if no categories are created

### DIFF
--- a/src/components/Modals/AddModal.vue
+++ b/src/components/Modals/AddModal.vue
@@ -73,7 +73,7 @@
               </v-row>
 
               <v-combobox v-model="tags" :items="availableTags" clearable :label="$t('tags')" :prepend-icon="mdiTag" multiple chips />
-              <v-combobox v-model="category" :items="availableCategories" clearable :label="$t('category')" item-text="name" :prepend-icon="mdiShape" @input="categoryChanged" />
+              <v-combobox v-model="category" :items="availableCategories" clearable :label="$t('category')" item-text="name" :prepend-icon="mdiLabel" @input="categoryChanged" />
 
               <v-text-field
                 v-model="directory"
@@ -142,7 +142,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import qbit from '@/services/qbit'
-import { mdiCloudUpload, mdiFolder, mdiTag, mdiShape, mdiPaperclip, mdiLink, mdiClose } from '@mdi/js'
+import { mdiCloudUpload, mdiFolder, mdiTag, mdiLabel, mdiPaperclip, mdiLink, mdiClose } from '@mdi/js'
 import { FullScreenModal, Modal } from '@/mixins'
 
 export default {
@@ -180,7 +180,7 @@ export default {
       mdiCloudUpload,
       mdiFolder,
       mdiTag,
-      mdiShape,
+      mdiLabel,
       mdiPaperclip,
       mdiLink,
       mdiClose

--- a/src/components/Torrent/TorrentRightClickMenu.vue
+++ b/src/components/Torrent/TorrentRightClickMenu.vue
@@ -149,10 +149,10 @@
         {{ $t('rightClick.notags') | titleCase }}
       </v-list-item-title>
     </v-list-item>
-    <v-menu :open-on-hover="!touchmode" top offset-x :transition="isRightside ? 'slide-x-reverse-transition' : 'slide-x-transition'" :left="isRightside">
+    <v-menu v-if="availableCategories.length > 1" :open-on-hover="!touchmode" top offset-x :transition="isRightside ? 'slide-x-reverse-transition' : 'slide-x-transition'" :left="isRightside">
       <template #activator="{ on }">
         <v-list-item link v-on="on">
-          <v-icon>{{ mdiShape }}</v-icon>
+          <v-icon>{{ mdiLabel }}</v-icon>
           <v-list-item-title class="ml-2 list-item__title">
             {{ $t('rightClick.category') | titleCase }}
           </v-list-item-title>
@@ -169,6 +169,12 @@
         </v-list-item>
       </v-list>
     </v-menu>
+    <v-list-item v-else>
+      <v-icon>{{ mdiLabelOff }}</v-icon>
+      <v-list-item-title class="ml-2 list-item__title">
+        {{ $t('rightClick.nocategory') | titleCase }}
+      </v-list-item-title>
+    </v-list-item>
     <v-menu v-if="!multiple" :open-on-hover="!touchmode" top offset-x :transition="isRightside ? 'slide-x-reverse-transition' : 'slide-x-transition'" :left="isRightside">
       <template #activator="{ on }">
         <v-list-item link v-on="on">
@@ -271,6 +277,8 @@ import {
   mdiFolder,
   mdiHeadCog,
   mdiInformation,
+  mdiLabel,
+  mdiLabelOff,
   mdiMagnet,
   mdiPause,
   mdiPlay,
@@ -279,7 +287,6 @@ import {
   mdiPriorityLow,
   mdiRenameBox,
   mdiSelect,
-  mdiShape,
   mdiSpeedometerSlow,
   mdiTag,
   mdiTagOff,
@@ -318,7 +325,8 @@ export default {
       mdiPriorityHigh,
       mdiBullhorn,
       mdiChevronRight,
-      mdiShape,
+      mdiLabel,
+      mdiLabelOff,
       mdiTag,
       mdiTagOff,
       mdiHeadCog,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -506,8 +506,9 @@
       "decrease": "Decrease"
     },
     "category": "Set Category",
+    "nocategory": "No Category",
     "tags": "Set Tags",
-    "notags": "No Tags",
+    "notags": "No Tag",
     "limit": "Set Limit",
     "copy": "Copy",
     "export": "Export Torrent | Export Torrents",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -492,6 +492,7 @@
       "decrease": "Diminuer"
     },
     "category": "Définir la catégorie",
+    "nocategory": "Aucune catégorie",
     "tags": "Définir les tags",
     "notags": "Aucun tag",
     "limit": "Définir la limite",


### PR DESCRIPTION
# Disable category selection in TRC menu if no categories are created [perf]

Disable category selection in TRC menu if no categories are created just like tags were already done.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
