### PR TITLE
fix: Unwanted torrent selection during search

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -395,7 +395,7 @@ export default {
         return null
       }
       // 'ctrl + A' => select torrents
-      if (e.keyCode === 65 && e.ctrlKey) {
+      if (e.keyCode === 65 && e.ctrlKey && e.target?.tagName !== 'INPUT') {
         e.preventDefault()
 
         this.selectAllTorrents()


### PR DESCRIPTION
# Unwanted torrent selection during search [fix]

Fixes: #253 

Fixed the annoying bug where the UI would select all visible torrents when you click CTRL + A while being focused on the filter/search input field

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
