### PR TITLE
fix: Fix incorrect enum values for MaxRatioAction

### DIFF
--- a/src/enums/qbit/AppPreferences.ts
+++ b/src/enums/qbit/AppPreferences.ts
@@ -22,10 +22,10 @@ export enum Encryption {
 }
 
 export enum MaxRatioAction {
-  PAUSE_TORRENT,
-  REMOVE_TORRENT,
-  REMOVE_TORRENT_AND_FILES,
-  ENABLE_SUPERSEEDING
+  PAUSE_TORRENT = 0,
+  REMOVE_TORRENT = 1,
+  REMOVE_TORRENT_AND_FILES = 3,
+  ENABLE_SUPERSEEDING = 2
 }
 
 export enum ProxyType {


### PR DESCRIPTION
# Fix incorrect enum values for MaxRatioAction [fix]

No idea why the two values got switched up
Source: https://github.com/qbittorrent/qBittorrent/blob/8df80b67f9f469a3240856f326d04da0ea221b11/src/base/bittorrent/session.h#L42-L50

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #672 