### PR TITLE
fix: Fix 400 when adding trackers

### DIFF
--- a/src/services/qbit.ts
+++ b/src/services/qbit.ts
@@ -340,7 +340,12 @@ export class QBitApi {
   }
 
   async addTorrentTrackers(hash: string, trackers: string): Promise<void> {
-    await this.torrentAction('addTrackers', [hash], { urls: trackers })
+    const params = {
+      hash,
+      urls: trackers
+    }
+
+    await this.execute(`/torrents/addTrackers`, params)
   }
 
   async removeTorrentTrackers(hash: string, trackers: string[]): Promise<void> {


### PR DESCRIPTION
# Fix 400 when adding trackers [fix]

Replace `hashes` param with `hash` param to prevent 400

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #667 