### PR TITLE
fix: Handle Windows path separators

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -60,7 +60,7 @@ export function treeify(paths) {
   const level = { result }
 
   paths.forEach(path => {
-    path.name.split('/').reduce((r, name) => {
+    path.name.split('\\').join('/').split('/').reduce((r, name) => {
       if (!r[name]) {
         r[name] = { result: [] }
         r.result.push(createFile(path, name, r[name].result))


### PR DESCRIPTION
# Handle Windows path separators [fix]

Handle '/' AND '\\' in torrents' content paths

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #663 