### PR TITLE
fix: Fix intervals

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -289,13 +289,13 @@ export default {
     }
   },
   mounted() {
+    this.$store.dispatch('INIT_INTERVALS')
     document.addEventListener('keydown', this.handleKeyboardShortcut)
     document.addEventListener('dragenter', this.detectDragEnter)
     this.$store.state.selectMode = false
     window.scrollTo(0, 0)
   },
   created() {
-    this.$store.dispatch('INIT_INTERVALS')
     this.$store.commit('FETCH_CATEGORIES')
     this.$store.commit('FETCH_TAGS')
     if (this.input) this.searchFilterEnabled = true

--- a/src/views/TorrentDetail.vue
+++ b/src/views/TorrentDetail.vue
@@ -84,16 +84,12 @@ export default {
     }
   },
   mounted() {
+    this.$store.dispatch('INIT_INTERVALS')
     document.addEventListener('keydown', this.handleKeyboardShortcut)
   },
-  created() {
-    this.$store.dispatch('INIT_INTERVALS')
-  },
   beforeDestroy() {
-    document.removeEventListener('keydown', this.handleKeyboardShortcut)
-  },
-  destroyed() {
     this.$store.commit('REMOVE_INTERVALS')
+    document.removeEventListener('keydown', this.handleKeyboardShortcut)
   },
   methods: {
     close() {


### PR DESCRIPTION
# Fix intervals [fix]

This PR fixes a bug in the intervals used to refresh main data continuously.
Before this fix, when you opened a torrent detail then the settings view, after coming back to the main dashboard, the interval were duplicated, issuing 2 requests per 2 secs (the second one being almost always equal to 0 made the graph flickering between 0 and the actual value).

Previous behaviour:

- Dashboard: created -> mounted (INIT_INTERVALS)
- TorrentDetail: **created** (INIT_INTERVALS)
  - overwriting dashboard's interval id
- Dashboard: beforeDestroy (REMOVE_INTERVALS)
  - clearing TorrentDetail's interval and leaving dashboard's interval lost in the oblivion
  - and thus causing the interval to duplicate each time the process is repeated

Fixed behaviour:
- Dashboard: created -> mounted (INIT_INTERVALS)
- Dashboard: beforeDestroy (REMOVE_INTERVALS)
- TorrentDetail: **mounted** (INIT_INTERVALS)

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
