### PR TITLE
perf: Add 'Ctrl + F' shortcut to focus search filter

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -9,6 +9,7 @@
       <v-expand-x-transition>
         <v-card v-show="searchFilterEnabled" id="searchFilter" flat xs7 md3 class="ma-0 pa-0 transparent">
           <v-text-field
+            id="searchInput"
             v-model="input"
             autofocus
             flat
@@ -399,6 +400,14 @@ export default {
         e.preventDefault()
 
         this.selectAllTorrents()
+      }
+
+      // 'ctrl + F' => Focus search filter field
+      if (e.keyCode === 70 && e.ctrlKey) {
+        e.preventDefault()
+
+        this.searchFilterEnabled = true
+        document.getElementById('searchInput').focus()
       }
 
       // 'Delete' => Delete modal


### PR DESCRIPTION
# Add 'Ctrl + F' shortcut to focus search filter [perf]

Added a shortcut to enable search filter if not already and focus the input.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
