### PR TITLE
fix: Ctrl key not being handled on Windows/Linux

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -204,5 +204,5 @@ export function isMac() {
 }
 
 export function doesCommand(e) {
-  return isMac ? e.metaKey : e.ctrlKey
+  return isMac() ? e.metaKey : e.ctrlKey
 }


### PR DESCRIPTION
# Ctrl key not being handled on Windows/Linux [fix]

Missing brackets so condition was always evaluated to true cause function exists 😬 

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
