### PR TITLE
feat!: Vue3 Migration

### DIFF
--- a/.github/workflows/vue3.yml
+++ b/.github/workflows/vue3.yml
@@ -1,0 +1,31 @@
+name: Build Vue3 nightly
+on:
+  push:
+    branches:
+      - vue3
+jobs:
+  push-nightly-vue3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Build Node.js cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build VueTorrent
+        run: npm run build
+      - name: Push to nightly-release
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: nightly-release-vue3
+          FOLDER: ./vuetorrent


### PR DESCRIPTION
# Vue3 migration

This PR will be used as the base for the migration to Vue3. It will be released on every commit, like we do for the nightlies, on it's own branch `nightly-release-vue3`.
We will use this PR to track progress and will add checkboxes for completed/needed to complete items.

- [ ] update tooling (eslint/test deps/vite config)
- [ ] update framework (vue3 + compat + vuetify)
- [ ] Pages
    - [ ] Login
    - [ ] Dashboard
- [ ] Components
   - [ ] Mobile Card
   - [ ] Desktop Card
- [ ] PWA Support
- [ ] Tests?
- [ ] Store to pinia??
- [ ] Store persistence?
