### PR TITLE
fix: fix the Chinese word order problem

### DIFF
--- a/src/lang/zh-hans.json
+++ b/src/lang/zh-hans.json
@@ -46,7 +46,7 @@
   "feed": "订阅源",
   "rule": "规则",
   "then": "时",
-  "of": "of",
+  "of": "中的",
   "yes": "是",
   "no": "否",
   "filter": "文件类型",
@@ -135,7 +135,7 @@
       "dark": "浅色模式",
       "light": "深色模式"
     },
-    "torrentsCount": "列表中无种子 | 共 {n} 个种子 | 共 {n} 个种子"
+    "torrentsCount": "列表中无种子 | {n} 个种子 | {n} 个种子"
   },
   "modals": {
     "newFeed": {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -21,9 +21,12 @@ export default {
   getAuthenticated: (state: StoreState) => () => state.authenticated,
   getTorrentCountString: (state: StoreState) => () => {
     if (state.selected_torrents && state.selected_torrents.length) {
-      return `${state.selected_torrents.length} ${i18n.t('of')} ${i18n.tc('navbar.torrentsCount', state.filteredTorrentsCount)}`
+      if (i18n.locale === 'zh-hans'||i18n.locale === 'zh-hant') {
+        return `${i18n.tc('navbar.torrentsCount', state.filteredTorrentsCount)}${i18n.t('of')} ${state.selected_torrents.length}`
+      }else{
+        return `${state.selected_torrents.length} ${i18n.t('of')} ${i18n.tc('navbar.torrentsCount', state.filteredTorrentsCount)}`
+      }
     }
-
     return i18n.tc('navbar.torrentsCount', state.filteredTorrentsCount)
   },
   getSearchPlugins: (state: StoreState) => () => state.searchPlugins


### PR DESCRIPTION
# fix: fix the Chinese word order problem

Modified part of the problem that the display is correct in English but the word order is wrong in Chinese. Both Simplified Chinese and Traditional Chinese are supported, but this is a temporary fix. Because this problem may not exist after refactoring.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
