### PR TITLE
perf: Register magnet handler

### DIFF
--- a/src/components/Settings/Tabs/VueTorrent/VGeneral.vue
+++ b/src/components/Settings/Tabs/VueTorrent/VGeneral.vue
@@ -221,6 +221,18 @@
       </v-row>
     </v-list-item>
     <v-list-item>
+      <v-row dense>
+        <v-col cols="7" sm="7" md="10">
+          <p class="subtitle-1">
+            {{ $t('modals.settings.pageVueTorrent.pageGeneral.registerMagnetHeader') }}
+          </p>
+        </v-col>
+        <v-col cols="4" sm="4" md="2">
+          <v-btn @click="registerMagnetHandler">{{ $t('modals.settings.pageVueTorrent.pageGeneral.registerMagnetButton') }}</v-btn>
+        </v-col>
+      </v-row>
+    </v-list-item>
+    <v-list-item>
       <v-textarea v-model="settingsField" />
     </v-list-item>
     <v-list-item class="remove-after justify-content-evenly">
@@ -296,6 +308,15 @@ export default {
     resetSettings() {
       window.localStorage.clear()
       location.reload()
+    },
+    registerMagnetHandler() {
+      if (typeof navigator.registerProtocolHandler !== 'function') {
+        this.$toast.error(this.$t("toast.magnetHandlerNotSupported").toString());
+        return;
+      }
+
+      const templateUrl = location.href.replace('/settings', '/download=%s')
+      navigator.registerProtocolHandler('magnet', templateUrl);
     }
   }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -237,6 +237,8 @@
           "showShutdownButton": "Show shutdown button",
           "currentVersion": "Current Version:",
           "qbittorrentVersion": "QBittorrent Version:",
+          "registerMagnetHeader": "Register to handle magnet links...",
+          "registerMagnetButton": "Register",
           "importSettings": "Import Settings",
           "exportSettings": "Export Settings",
           "resetSettings": "Reset Settings"
@@ -556,7 +558,8 @@
     "pasteNotSupported": "Unable to paste, context isn't secured",
     "shutdownSuccess": "qBittorrent was shutdown successfully!",
     "shutdownError": "Unable to shutdown app. Make sure qBittorrent is running!",
-    "invalidJson": "Invalid JSON! Check console for details"
+    "invalidJson": "Invalid JSON! Check console for details",
+    "magnetHandlerNotSupported": "Unable to register handler, context isn't secured!"
   },
   "rightClick": {
     "resume": "resume",

--- a/tests/unit/__snapshots__/General.spec.ts.snap
+++ b/tests/unit/__snapshots__/General.spec.ts.snap
@@ -134,6 +134,16 @@ exports[`General > render correctly 1`] = `
     </v-row-stub>
   </v-list-item-stub>
   <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\">
+    <v-row-stub data-v-7da6d3e2=\\"\\" tag=\\"div\\" dense=\\"true\\">
+      <v-col-stub data-v-7da6d3e2=\\"\\" cols=\\"7\\" sm=\\"7\\" md=\\"10\\" tag=\\"div\\">
+        <p data-v-7da6d3e2=\\"\\" class=\\"subtitle-1\\"> </p>
+      </v-col-stub>
+      <v-col-stub data-v-7da6d3e2=\\"\\" cols=\\"4\\" sm=\\"4\\" md=\\"2\\" tag=\\"div\\">
+        <v-btn-stub data-v-7da6d3e2=\\"\\" tag=\\"button\\" activeclass=\\"\\" type=\\"button\\"></v-btn-stub>
+      </v-col-stub>
+    </v-row-stub>
+  </v-list-item-stub>
+  <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\">
     <v-textarea-stub data-v-7da6d3e2=\\"\\" errorcount=\\"1\\" errormessages=\\"\\" messages=\\"\\" rules=\\"\\" successmessages=\\"\\" value=\\"\\" backgroundcolor=\\"\\" loaderheight=\\"2\\" clearicon=\\"$clear\\" type=\\"text\\" rowheight=\\"24\\" rows=\\"5\\"></v-textarea-stub>
   </v-list-item-stub>
   <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\" class=\\"remove-after justify-content-evenly\\">


### PR DESCRIPTION
# Register magnet handler [perf]

Adds a button in the settings view to register magnet handler.

source: https://github.com/qbittorrent/qBittorrent/blob/cddf8c199cdc364548e2ca827ae37e92476515cd/src/webui/www/private/scripts/client.js#L1404-L1423

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #111
Fixes #781
