### PR TITLE
perf: Show autorun command tooltip when either checkbox is checked

### DIFF
--- a/src/components/Settings/Tabs/Downloads.vue
+++ b/src/components/Settings/Tabs/Downloads.vue
@@ -62,7 +62,7 @@
     <v-list-item v-if="settings.autorun_enabled">
       <v-text-field v-model="settings.autorun_program" class="mb-2" outlined dense :label="$t('modals.settings.pageDownloads.saveManagement.autoLabel_onFinished')" hide-details />
     </v-list-item>
-    <v-list-item v-if="settings.autorun_enabled" class="mb-4">
+    <v-list-item v-if="settings.autorun_on_torrent_added_enabled || settings.autorun_enabled" class="mb-4">
       <v-card flat color="grey--text selected">
         <v-card-text>
           <h5>


### PR DESCRIPTION
# Show autorun command tooltip when either checkbox is checked [perf]

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
