### PR TITLE
feat: limit updateMainData to one request at once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vuetorrent",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "dependencies": {
         "ajv": "^8.12.0",
         "apexcharts": "^3.35.0",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -88,6 +88,7 @@ export default new Vuex.Store<StoreState>({
     download_data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     filteredTorrentsCount: 0,
     intervals: [],
+    isUpdatingMainData: false,
     latestSelectedTorrent: -1,
     modals: [],
     rid: 0,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -53,6 +53,9 @@ export default {
     state.authenticated = payload
   },
   updateMainData: async (state: StoreState) => {
+    if (state.isUpdatingMainData) return
+    state.isUpdatingMainData = true
+
     try {
       const response = await qbit.getMainData(state.rid || undefined)
       state.rid = response.rid || undefined
@@ -74,6 +77,8 @@ export default {
         state.authenticated = false
         router.push({ name: 'login' })
       }
+    } finally {
+      state.isUpdatingMainData = false
     }
   },
   FETCH_SETTINGS: async (state: StoreState, settings: AppPreferences) => {

--- a/src/types/vuetorrent/StoreState.ts
+++ b/src/types/vuetorrent/StoreState.ts
@@ -24,6 +24,7 @@ export default interface StoreState extends PersistentStoreState {
   download_data: number[]
   filteredTorrentsCount: number
   intervals: NodeJS.Timer[]
+  isUpdatingMainData: boolean
   latestSelectedTorrent: number
   modals: ModalTemplate[]
   rid?: number


### PR DESCRIPTION
This pull request limits `updateMainData` requests to at most one at the same time.

On my Raspberry Pi it can happen that a request takes longer than the interval (2 seconds in [current implementation](https://github.com/WDaan/VueTorrent/blob/2fdeb63c83eee6bbcdcc0bc639a4d3d303f10e20/src/store/actions.ts#L12)) when qBittorrent is busy. The current polling method, which makes a request every 2 seconds without exception, can cause multiple identical requests, resulting in even longer response time.