### PR TITLE
perf: Extend RSS Feeds / Rules to use full width instead of half

### DIFF
--- a/src/components/Settings/Tabs/Rss/Feeds.vue
+++ b/src/components/Settings/Tabs/Rss/Feeds.vue
@@ -1,9 +1,8 @@
 <template>
   <v-card flat>
     <v-row dense class="ma-0 pa-0">
-      <v-col cols="12" md="6">
-        <v-subheader>{{ $t('modals.settings.rss.feeds.feeds') }}</v-subheader>
-        <template v-for="(item, index) in availableFeeds">
+      <template v-for="(item, index) in availableFeeds">
+        <v-col cols="12" sm="6" lg="4" xl="2">
           <v-list-item :key="item.uid">
             <v-list-item-content>
               <v-list-item-title v-text="item.name" />
@@ -24,29 +23,32 @@
               </v-icon>
             </v-list-item-action>
           </v-list-item>
-          <v-divider v-if="index < availableFeeds.length - 1" :key="index" />
-        </template>
-        <v-list-item>
-          <v-btn class="mx-auto accent white--text elevation-0 px-4" @click="createFeed">
-            {{ $t('modals.settings.rss.feeds.btnCreateNew') }}
-          </v-btn>
-          <v-btn class="mx-auto accent white--text elevation-0 px-4" @click="refreshAll">
-            {{ $t('modals.settings.rss.feeds.refreshAll') }}
-          </v-btn>
-        </v-list-item>
+          <v-divider :key="index" />
+        </v-col>
+      </template>
+    </v-row>
+    <v-row class="mb-3">
+      <v-col cols="6" class="d-flex align-center justify-center">
+        <v-btn class="mx-auto accent white--text elevation-0 px-4" @click="createFeed">
+          {{ $t('modals.settings.rss.feeds.btnCreateNew') }}
+        </v-btn>
+      </v-col>
+      <v-col cols="6" class="d-flex align-center justify-center">
+        <v-btn class="mx-auto accent white--text elevation-0 px-4" @click="refreshAll">
+          {{ $t('modals.settings.rss.feeds.refreshAll') }}
+        </v-btn>
       </v-col>
     </v-row>
   </v-card>
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { mapGetters } from 'vuex'
-import qbit from '@/services/qbit'
 import { mdiDelete, mdiPencil, mdiSync } from '@mdi/js'
-
+import qbit from '@/services/qbit'
 import { Tab, General, FullScreenModal } from '@/mixins'
 import { Feed } from '@/types/vuetorrent'
-import { defineComponent } from 'vue'
 
 export default defineComponent({
   name: 'Feeds',
@@ -58,9 +60,9 @@ export default defineComponent({
   }),
   computed: {
     ...mapGetters(['getFeeds']),
-    availableFeeds() {
+    availableFeeds(): Feed[] {
       // @ts-expect-error: TS2349: This expression is not callable. Type 'never' has no call signatures.
-      return this.getFeeds() as Feed[]
+      return this.getFeeds()
     }
   },
   created() {

--- a/src/components/Settings/Tabs/Rss/Feeds.vue
+++ b/src/components/Settings/Tabs/Rss/Feeds.vue
@@ -1,31 +1,29 @@
 <template>
   <v-card flat>
     <v-row dense class="ma-0 pa-0">
-      <template v-for="(item, index) in availableFeeds">
-        <v-col cols="12" sm="6" lg="4" xl="2">
-          <v-list-item :key="item.uid">
-            <v-list-item-content>
-              <v-list-item-title v-text="item.name" />
-            </v-list-item-content>
-            <v-list-item-action class="icon">
-              <v-icon @click="updateFeed(item)">
-                {{ mdiSync }}
-              </v-icon>
-            </v-list-item-action>
-            <v-list-item-action class="icon">
-              <v-icon @click="editFeed(item)">
-                {{ mdiPencil }}
-              </v-icon>
-            </v-list-item-action>
-            <v-list-item-action class="icon">
-              <v-icon color="red" @click="deleteFeed(item)">
-                {{ mdiDelete }}
-              </v-icon>
-            </v-list-item-action>
-          </v-list-item>
-          <v-divider :key="index" />
-        </v-col>
-      </template>
+      <v-col cols="12" sm="6" lg="3" v-for="item in availableFeeds" :key="item.uid">
+        <v-list-item>
+          <v-list-item-content>
+            <v-list-item-title v-text="item.name" />
+          </v-list-item-content>
+          <v-list-item-action class="icon">
+            <v-icon @click="updateFeed(item)">
+              {{ mdiSync }}
+            </v-icon>
+          </v-list-item-action>
+          <v-list-item-action class="icon">
+            <v-icon @click="editFeed(item)">
+              {{ mdiPencil }}
+            </v-icon>
+          </v-list-item-action>
+          <v-list-item-action class="icon">
+            <v-icon color="red" @click="deleteFeed(item)">
+              {{ mdiDelete }}
+            </v-icon>
+          </v-list-item-action>
+        </v-list-item>
+        <v-divider />
+      </v-col>
     </v-row>
     <v-row class="mb-3">
       <v-col cols="6" class="d-flex align-center justify-center">

--- a/src/components/Settings/Tabs/Rss/Rules.vue
+++ b/src/components/Settings/Tabs/Rss/Rules.vue
@@ -1,8 +1,8 @@
 <template>
   <v-card flat>
     <v-row dense class="ma-0 pa-0">
-      <v-col cols="12" sm="6" lg="4" xl="2" v-for="(item, index) in availableRules">
-        <v-list-item :key="item.uid">
+      <v-col cols="12" sm="6" lg="3" v-for="(item, index) in availableRules" :key="item.uid">
+        <v-list-item>
           <v-list-item-content>
             <v-list-item-title v-text="item.name" />
           </v-list-item-content>
@@ -22,7 +22,7 @@
             </v-icon>
           </v-list-item-action>
         </v-list-item>
-        <v-divider :key="index" />
+        <v-divider />
       </v-col>
     </v-row>
     <v-row class="mb-3">

--- a/src/components/Settings/Tabs/Rss/Rules.vue
+++ b/src/components/Settings/Tabs/Rss/Rules.vue
@@ -1,36 +1,35 @@
 <template>
   <v-card flat>
     <v-row dense class="ma-0 pa-0">
-      <v-col cols="12" md="6">
-        <v-subheader>{{ $t('modals.settings.rss.rules.rules') }}</v-subheader>
-        <template v-for="(item, index) in availableRules">
-          <v-list-item :key="item.uid">
-            <v-list-item-content>
-              <v-list-item-title v-text="item.name" />
-            </v-list-item-content>
-            <v-list-item-action class="icon">
-              <v-icon @click="previewMatchingArticles(item.name)">
-                {{ mdiEye }}
-              </v-icon>
-            </v-list-item-action>
-            <v-list-item-action class="icon">
-              <v-icon @click="editRule(item)">
-                {{ mdiPencil }}
-              </v-icon>
-            </v-list-item-action>
-            <v-list-item-action>
-              <v-icon color="red" @click="deleteRule(item)">
-                {{ mdiDelete }}
-              </v-icon>
-            </v-list-item-action>
-          </v-list-item>
-          <v-divider v-if="index < availableRules.length - 1" :key="index" />
-        </template>
-        <v-list-item>
-          <v-btn class="mx-auto accent white--text elevation-0 px-4" @click="createRule">
-            {{ $t('modals.settings.rss.rules.btnCreateNew') }}
-          </v-btn>
+      <v-col cols="12" sm="6" lg="4" xl="2" v-for="(item, index) in availableRules">
+        <v-list-item :key="item.uid">
+          <v-list-item-content>
+            <v-list-item-title v-text="item.name" />
+          </v-list-item-content>
+          <v-list-item-action class="icon">
+            <v-icon @click="previewMatchingArticles(item.name)">
+              {{ mdiEye }}
+            </v-icon>
+          </v-list-item-action>
+          <v-list-item-action class="icon">
+            <v-icon @click="editRule(item)">
+              {{ mdiPencil }}
+            </v-icon>
+          </v-list-item-action>
+          <v-list-item-action>
+            <v-icon color="red" @click="deleteRule(item)">
+              {{ mdiDelete }}
+            </v-icon>
+          </v-list-item-action>
         </v-list-item>
+        <v-divider :key="index" />
+      </v-col>
+    </v-row>
+    <v-row class="mb-3">
+      <v-col cols="12" class="d-flex align-center justify-center">
+        <v-btn class="mx-auto accent white--text elevation-0 px-4" @click="createRule">
+          {{ $t('modals.settings.rss.rules.btnCreateNew') }}
+        </v-btn>
       </v-col>
     </v-row>
   </v-card>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -446,12 +446,10 @@
           }
         },
         "feeds": {
-          "feeds": "Feeds",
           "btnCreateNew": "Add feed",
           "refreshAll": "Refresh All"
         },
         "rules": {
-          "rules": "Rules",
           "btnCreateNew": "Create Rule"
         }
       },


### PR DESCRIPTION
# Extend RSS Feeds / Rules to use full width instead of half [perf]

From this:
![image](https://github.com/WDaan/VueTorrent/assets/22910497/827ef1c4-a4c2-4ba4-a886-e74190134619)

To that:
![image](https://github.com/WDaan/VueTorrent/assets/22910497/c0820ed7-2648-4f77-b2e6-5c944e501192)

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
