### PR TITLE
fix: select label color is white (regardless of the selected theme)

### DIFF
--- a/src/components/Navbar/FilterSelect.vue
+++ b/src/components/Navbar/FilterSelect.vue
@@ -201,12 +201,16 @@ export default {
   color: #64ceaa !important;
 }
 .v-select__slot > label {
-  color: white !important;
+  &.theme--dark {
+    color: white !important;
+  }
+  &.theme--light {
+    color: black !important;
+  }
 }
 #app .v-select .v-text-field__details {
   display: none;
 }
-
 #app .v-select .v-select__selection {
   padding: 16px 0;
   margin: 0;


### PR DESCRIPTION
# select label color is white (regardless of the selected theme) [fix]

Add theme filters to prevent white text on white background on select labels

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements

Fixes #810 