### PR TITLE
fix: context-menu not appearing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta name="theme-color" content="#000" />
     <title>qBittorrent</title>
   </head>
-  <body oncontextmenu="return false">
+  <body>
     <noscript>
       <strong>We're sorry but Vuetorrent doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
# Fix context-menu not appearing [fix]
The body contains `oncontextmenu="return false"`, which, at least in all my test environments, causes all context menus to be blocked. This removes the ability to paste magnets on android (not sure about IOS).
The context-menu blocking is already handled by `blockContextMenu()` in `App.vue`, which handles TEXTAREAs etc. correctly, so this shouldn't break anything (according to my testing).

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
