### PR TITLE
perf: Add right click exception on link elements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,7 +57,7 @@ export default {
         const nodeName = event.target.nodeName.toLowerCase()
         const nodeType = event.target.getAttribute('type')
 
-        if (nodeName === 'textarea') return
+        if (['textarea', 'a'].includes(nodeName)) return
         if (nodeName === 'input' && ['text', 'password', 'email', 'number'].includes(nodeType)) return
 
         event.preventDefault()


### PR DESCRIPTION
# Add right click exception on link elements [perf]

Adds an exception to allow users to right click on <a> tags (links basically). This can be useful in the case where the user wants to open a link in a new tab / window / private window (e.g. rss article)

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
