### PR TITLE
perf: Add TorrentDetail overview tab

### DIFF
--- a/src/actions/Tags.ts
+++ b/src/actions/Tags.ts
@@ -5,7 +5,7 @@ import type { MainDataResponse } from '@/types/qbit/responses'
 export class Tags {
   static update(response: MainDataResponse) {
     if (response?.fullUpdate === true) {
-      store.state.tags = response.tags || []
+      store.state.tags = response.tags
 
       return
     }

--- a/src/actions/Torrents.ts
+++ b/src/actions/Torrents.ts
@@ -19,10 +19,11 @@ export class Torrents {
     store.state.torrents = data.map(t => new VtTorrent(t, store.state.webuiSettings.dateFormat))
 
     // load fake torrents if enabled
-    if (isProduction()) return
-    if (import.meta.env.VITE_USE_FAKE_TORRENTS === 'false') return
-    const count = import.meta.env.VITE_FAKE_TORRENT_COUNT
-    store.state.torrents.push(...generateMultiple(count))
+    if (!isProduction()) {
+      if (import.meta.env.VITE_USE_FAKE_TORRENTS === 'false') return
+      const count = import.meta.env.VITE_FAKE_TORRENT_COUNT
+      store.state.torrents.push(...generateMultiple(count))
+    }
 
     // filter out deleted torrents from selection
     const hash_index = store.state.torrents.map(torrent => torrent.hash)

--- a/src/components/Torrent/DashboardItems/Tags.vue
+++ b/src/components/Torrent/DashboardItems/Tags.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-flex v-if="torrent.tags && torrent.tags.length" xs6 sm2>
+  <v-flex v-if="torrent?.tags && torrent.tags.length" xs6 sm2>
     <div class="caption grey--text">
       {{ $t('torrent.properties.tags') }}
     </div>

--- a/src/components/TorrentDetail/Tabs/Content.vue
+++ b/src/components/TorrentDetail/Tabs/Content.vue
@@ -10,8 +10,8 @@
         </v-icon>
       </template>
       <template #label="{ item }">
-        <span class="item-name" v-if="!item.editing">{{ item.name }}</span>
         <v-text-field v-if="item.editing" v-model="item.newName" autofocus />
+        <span class="item-name" v-else>{{ item.name }}</span>
       </template>
       <template #append="{ item }">
         <div v-if="!item.icon">

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -4,7 +4,13 @@
       <v-col cols="6">
         <v-card flat>
           <v-card-title>{{ torrent.name }}</v-card-title>
-          <v-card-subtitle><v-btn text @click="copyHash">{{ torrent.hash }}</v-btn></v-card-subtitle>
+          <v-card-subtitle>
+            <span v-for="commentPart in splitString(comment)" :key="commentPart">
+              <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
+              <span v-else>{{ commentPart }}</span>
+            </span>
+            <v-btn text @click="copyHash">{{ torrent.hash }}</v-btn>
+          </v-card-subtitle>
           <v-card-text>
             <v-row>
               <v-col cols="3">

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -48,6 +48,32 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-row>
+      <v-simple-table>
+        <tbody>
+          <tr id="torrentSavePath">
+            <td :class="commonStyle">
+              {{ $t('torrent.properties.save_path') }}
+            </td>
+            <td>
+              {{ torrent.savePath }}
+            </td>
+          </tr>
+          <tr id="torrentSize">
+            <td :class="commonStyle">
+              Selected Size
+            </td>
+            <td>
+              {{ torrent.size | getDataValue }}
+              {{ torrent.size | getDataUnit }}
+              /
+              {{ torrent.total_size | getDataValue }}
+              {{ torrent.total_size | getDataUnit }}
+            </td>
+          </tr>
+        </tbody>
+      </v-simple-table>
+    </v-row>
   </v-flex>
 </template>
 
@@ -84,11 +110,11 @@ export default defineComponent({
       uploadSpeedAvg: 0,
       mdiClose,
       mdiPencil,
-      mdiContentSave
+      mdiContentSave,
+      TorrentState
     }
   },
   async mounted() {
-    console.log(this.torrent?.tags && this.torrent.tags.length > 0)
     await this.getTorrentProperties()
     await this.renderTorrentPieceStates()
   },

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -1,326 +1,58 @@
 <template>
-  <v-card flat>
-    <v-simple-table>
-      <tbody>
-        <tr id="torrentName">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.torrentTitle') }}
-          </td>
-          <td>
-            {{ torrent.name }}
-          </td>
-        </tr>
-        <tr id="torrentComment" v-if="comment">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.comments') | titleCase }}
-          </td>
-          <td>
-            <span v-for="commentPart in splitString(comment)" :key="commentPart">
-              <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
-              <span v-else>{{ commentPart }}</span>
-            </span>
-          </td>
-        </tr>
-        <tr id="torrentPieceState">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.pieceStates') }}
-          </td>
-          <td id="pieceStates" class="d-flex">
-            <span class="mr-2 align-center d-flex"> {{ torrent.progress }}% </span>
-            <canvas width="0" height="1" />
-          </td>
-        </tr>
-        <tr id="torrentSavePath">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.save_path') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.savePath }}
-          </td>
-        </tr>
-        <tr id="torrentHash">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.hash') }}
-          </td>
-          <td>
-            {{ torrent.hash }}
-          </td>
-        </tr>
-        <tr id="torrentSize">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.size') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.size | getDataValue }}
-            {{ torrent.size | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentTotalSize">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.total_size') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.total_size | getDataValue }}
-            {{ torrent.total_size | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentTimeActive">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.time_active') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.time_active }}
-            <span>{{ seedingTime }}</span>
-          </td>
-        </tr>
-        <tr id="torrentDownloaded">
-          <td :class="commonStyle">
-            {{ $t('torrent.downloaded') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.downloaded | getDataValue }}
-            {{ torrent.downloaded | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentUploaded">
-          <td :class="commonStyle">
-            {{ $t('torrent.uploaded') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.uploaded | getDataValue }}
-            {{ torrent.uploaded | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentRatio">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.ratio') }}
-          </td>
-          <td>
-            {{ torrent.ratio }}
-          </td>
-        </tr>
-        <tr id="torrentDlSpeed">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.downloadSpeed') }}
-          </td>
-          <td>
-            {{ torrent.dlspeed | getDataValue }}
-            {{ torrent.dlspeed | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentDlSpeedAvg">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.dl_speed_average') | titleCase }}
-          </td>
-          <td>
-            {{ downloadSpeedAvg | getDataValue }}
-            {{ downloadSpeedAvg | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentUpSpeed">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.uploadSpeed') }}
-          </td>
-          <td>
-            {{ torrent.upspeed | getDataValue }}
-            {{ torrent.upspeed | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentUpSpeedAvg">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.up_speed_average') | titleCase }}
-          </td>
-          <td>
-            {{ uploadSpeedAvg | getDataValue }}
-            {{ uploadSpeedAvg | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentEta">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.eta') }}
-          </td>
-          <td>
-            {{ torrent.eta }}
-          </td>
-        </tr>
-        <tr id="torrentPeers">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.peers') }}
-          </td>
-          <td>
-            {{ torrent.num_leechs }}<span :class="commonStyle">/{{ torrent.available_peers }}</span>
-          </td>
-        </tr>
-        <tr id="torrentSeeds">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.seeds') }}
-          </td>
-          <td>
-            {{ torrent.num_seeds }}<span :class="commonStyle">/{{ torrent.available_seeds }}</span>
-          </td>
-        </tr>
-        <tr id="torrentAddedOn">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.added_on') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.added_on }}
-          </td>
-        </tr>
-        <tr id="torrentCreationDate">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.creation_date') | titleCase }}
-          </td>
-          <td>
-            {{ creationDate }}
-          </td>
-        </tr>
-        <tr id="torrentState">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.status') }}
-          </td>
-          <td>
-            <v-chip small :class="`${torrentStateClass} white--text caption`">
-              {{ torrent.state }}
-            </v-chip>
-          </td>
-        </tr>
-        <tr id="torrentTrackers" v-if="torrent?.tracker">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.trackers') }}
-          </td>
-          <td>
-            <span v-for="trackersPart in splitString(torrent.tracker)" :key="trackersPart">
-              <a v-if="stringContainsUrl(trackersPart)" target="_blank" :href="trackersPart">{{ trackersPart }}</a>
-              <span v-else>{{ trackersPart }}</span>
-            </span>
-          </td>
-        </tr>
-        <tr id="torrentCreatedBy" v-if="createdBy">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.createdBy') }}
-          </td>
-          <td>
-            <span v-for="createdByPart in splitString(createdBy)" :key="createdByPart">
-              <a v-if="stringContainsUrl(createdByPart)" target="_blank" :href="createdByPart">{{ createdByPart }}</a>
-              <span v-else>{{ createdByPart }}</span>
-            </span>
-          </td>
-        </tr>
-
-        <tr id="torrentFLPiecePrio">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.firstLastPiecePriority') }}
-          </td>
-          <td>
-            {{ torrent.f_l_piece_prio }}
-          </td>
-        </tr>
-        <tr id="torrentSeqDl">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.sequentialDownload') }}
-          </td>
-          <td>
-            {{ torrent.seq_dl }}
-          </td>
-        </tr>
-        <tr id="torrentAutoTMM">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.autoTMM') }}
-          </td>
-          <td>
-            {{ torrent.auto_tmm }}
-          </td>
-        </tr>
-        <tr id="torrentRatioLimit">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.shareRatioLimit') }}
-          </td>
-          <td>
-            {{ torrent.ratio_limit | limitToValue }}
-          </td>
-        </tr>
-        <tr id="torrentRatioTimeLimit">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.shareTimeLimit') }}
-          </td>
-          <td>
-            {{ torrent.ratio_time_limit | limitToValue }}
-          </td>
-        </tr>
-        <tr id="torrentDlLimit">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.downloadLimit') }}
-          </td>
-          <td v-if="torrent?.dl_limit > 0">
-            {{ torrent.dl_limit | getDataValue }}
-            {{ torrent.dl_limit | getDataUnit }}<span>/s </span>
-          </td>
-          <td v-else>∞</td>
-        </tr>
-        <tr id="torrentUpLimit">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.uploadLimit') }}
-          </td>
-          <td v-if="torrent?.up_limit > 0">
-            {{ torrent.up_limit | getDataValue }}
-            {{ torrent.up_limit | getDataUnit }}<span>/s </span>
-          </td>
-          <td v-else>∞</td>
-        </tr>
-        <tr id="torrentAvailability">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.availability') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.availability }}
-          </td>
-        </tr>
-        <tr id="torrentPrivate">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.is_private') | titleCase }}
-          </td>
-          <td>
-            {{ isPrivateTorrent }}
-          </td>
-        </tr>
-        <tr id="torrentPieceCount">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.piece_owned') | titleCase }}
-          </td>
-          <td>{{ torrentPieceOwned }} / {{ torrentPieceCount }}</td>
-        </tr>
-        <tr id="torrentPieceSize">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.piece_size') | titleCase }}
-          </td>
-          <td>
-            {{ torrentPieceSize | getDataValue }}
-            {{ torrentPieceSize | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentWastedSize">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.wasted_size') | titleCase }}
-          </td>
-          <td>
-            {{ wastedSize | getDataValue }}
-            {{ wastedSize | getDataUnit }}
-          </td>
-        </tr>
-      </tbody>
-    </v-simple-table>
-  </v-card>
+  <v-flex>
+    <v-row>
+      <v-col cols="6">
+        <v-card flat>
+          <v-card-title>{{ torrent.name }}</v-card-title>
+          <v-card-subtitle><v-btn text @click="copyHash">{{ torrent.hash }}</v-btn></v-card-subtitle>
+          <v-card-text>
+            <v-row>
+              <v-col cols="3">
+                <v-progress-circular :rotate="-90" :size="100" :width="15" :value="torrent?.progress ?? 0" color="accent">{{ torrent.progress ?? 0 }} %</v-progress-circular>
+              </v-col>
+              <v-col cols="9" class="d-flex align-center justify-center">
+                <canvas id="pieceStates" width="0" height="1" />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="6">
+        <v-card flat>
+          <v-card-text>
+            <v-list-item>
+              {{ $t('modals.detail.pageInfo.status') }}:
+              <v-chip small :class="`${torrentStateClass} white--text caption ml-2`">{{ torrent.state }}</v-chip>
+            </v-list-item>
+            <v-list-item>
+              {{ $t('torrent.properties.category') }}:
+              <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : '(no cat)' }}</v-chip>
+            </v-list-item>
+            <v-list-item>
+              {{ $t('torrent.properties.tracker') }}:
+              <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : '(no tracker)' }}</v-chip>
+            </v-list-item>
+            <v-list-item>
+              {{ $t('torrent.properties.tags') }}:
+              <v-chip v-if="torrent?.tags" v-for="tag in torrent.tags" :key="tag" small class="tags white--text caption ml-2">{{ tag }}</v-chip>
+              <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">(no tags)</v-chip>
+            </v-list-item>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-flex>
 </template>
 
 <script lang="ts">
 import dayjs from 'dayjs'
 import { FullScreenModal } from '@/mixins'
 import qbit from '@/services/qbit'
-import { splitByUrl, stringContainsUrl } from '@/helpers'
+import {getDomainBody, splitByUrl, stringContainsUrl} from '@/helpers'
 import { defineComponent } from 'vue'
 import { Torrent } from '@/models'
 import { mapState } from 'vuex'
+import { mdiPencil, mdiContentSave, mdiClose } from '@mdi/js'
 
 export default defineComponent({
   name: 'Info',
@@ -341,10 +73,14 @@ export default defineComponent({
       torrentPieceOwned: 0,
       torrentPieceCount: 0,
       wastedSize: 0,
-      uploadSpeedAvg: 0
+      uploadSpeedAvg: 0,
+      mdiClose,
+      mdiPencil,
+      mdiContentSave
     }
   },
   async mounted() {
+    console.log(this.torrent?.tags && this.torrent.tags.length > 0)
     await this.getTorrentProperties()
     await this.renderTorrentPieceStates()
   },
@@ -366,6 +102,7 @@ export default defineComponent({
     }
   },
   methods: {
+    getDomainBody,
     async getTorrentProperties() {
       const props = await qbit.getTorrentProperties(this.torrent?.hash as string)
       this.comment = props.comment
@@ -381,7 +118,7 @@ export default defineComponent({
       this.uploadSpeedAvg = props.up_speed_avg
     },
     async renderTorrentPieceStates() {
-      const canvas: HTMLCanvasElement | null = document.querySelector('#pieceStates canvas')
+      const canvas: HTMLCanvasElement | null = document.querySelector('canvas#pieceStates')
       if (canvas === null) return
 
       const files = await qbit.getTorrentFiles(this.torrent?.hash as string)
@@ -443,6 +180,14 @@ export default defineComponent({
     },
     splitString(string: string) {
       return splitByUrl(string)
+    },
+    async copyHash() {
+      try {
+        await navigator.clipboard.writeText(this.torrent?.hash as string);
+        console.log('Content copied to clipboard');
+      } catch (err) {
+        console.error('Failed to copy: ', err);
+      }
     }
   }
 })
@@ -467,13 +212,9 @@ export default defineComponent({
   width: 20%;
 }
 
-#pieceStates {
-  display: block;
-
-  canvas {
-    height: 100%;
-    width: 75%;
-    border: 1px dotted;
-  }
+canvas#pieceStates {
+  height: 50%;
+  width: 100%;
+  border: 1px dotted;
 }
 </style>

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -8,7 +8,8 @@
           <v-card-text>
             <v-row>
               <v-col cols="3">
-                <v-progress-circular :rotate="-90" :size="100" :width="15" :value="torrent?.progress ?? 0" color="accent">{{ torrent.progress ?? 0 }} %</v-progress-circular>
+                <v-progress-circular v-if="torrent?.state === TorrentState.METADATA" indeterminate :size="100" color="torrent-metadata">Fetching...</v-progress-circular>
+                <v-progress-circular v-else :rotate="-90" :size="100" :width="15" :value="torrent?.progress ?? 0" color="accent">{{ torrent.progress ?? 0 }} %</v-progress-circular>
               </v-col>
               <v-col cols="9" class="d-flex align-center justify-center">
                 <canvas id="pieceStates" width="0" height="1" />
@@ -45,14 +46,15 @@
 </template>
 
 <script lang="ts">
-import dayjs from 'dayjs'
-import { FullScreenModal } from '@/mixins'
-import qbit from '@/services/qbit'
-import {getDomainBody, splitByUrl, stringContainsUrl} from '@/helpers'
-import { defineComponent } from 'vue'
-import { Torrent } from '@/models'
-import { mapState } from 'vuex'
-import { mdiPencil, mdiContentSave, mdiClose } from '@mdi/js'
+import dayjs from "dayjs";
+import { FullScreenModal } from "@/mixins";
+import qbit from "@/services/qbit";
+import { getDomainBody, splitByUrl, stringContainsUrl } from "@/helpers";
+import { defineComponent } from "vue";
+import { Torrent } from "@/models";
+import { mapState } from "vuex";
+import { mdiClose, mdiContentSave, mdiPencil } from "@mdi/js";
+import { TorrentState } from "@/enums/vuetorrent";
 
 export default defineComponent({
   name: 'Info',

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -1,92 +1,326 @@
 <template>
-  <v-flex>
-    <v-row>
-      <v-col cols="6">
-        <v-card flat>
-          <v-card-title>{{ torrent.name }}</v-card-title>
-          <v-card-subtitle>
+  <v-card flat>
+    <v-simple-table>
+      <tbody>
+        <tr id="torrentName">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.torrentTitle') }}
+          </td>
+          <td>
+            {{ torrent.name }}
+          </td>
+        </tr>
+        <tr id="torrentComment" v-if="comment">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.comments') | titleCase }}
+          </td>
+          <td>
             <span v-for="commentPart in splitString(comment)" :key="commentPart">
               <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
               <span v-else>{{ commentPart }}</span>
             </span>
-            <v-btn text @click="copyHash">{{ torrent.hash }}</v-btn>
-          </v-card-subtitle>
-          <v-card-text>
-            <v-row>
-              <v-col cols="3">
-                <v-progress-circular v-if="torrent?.state === TorrentState.METADATA" indeterminate :size="100" color="torrent-metadata">Fetching...</v-progress-circular>
-                <v-progress-circular v-else :rotate="-90" :size="100" :width="15" :value="torrent?.progress ?? 0" color="accent">{{ torrent.progress ?? 0 }} %</v-progress-circular>
-              </v-col>
-              <v-col cols="9" class="d-flex align-center justify-center">
-                <canvas id="pieceStates" width="0" height="1" />
-              </v-col>
-            </v-row>
-          </v-card-text>
-        </v-card>
-      </v-col>
-      <v-col cols="6">
-        <v-card flat>
-          <v-card-text>
-            <v-list-item>
-              {{ $t('modals.detail.pageInfo.status') }}:
-              <v-chip small :class="`${torrentStateClass} white--text caption ml-2`">{{ torrent.state }}</v-chip>
-            </v-list-item>
-            <v-list-item>
-              {{ $t('torrent.properties.category') }}:
-              <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : '(no cat)' }}</v-chip>
-            </v-list-item>
-            <v-list-item>
-              {{ $t('torrent.properties.tracker') }}:
-              <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : '(no tracker)' }}</v-chip>
-            </v-list-item>
-            <v-list-item>
-              {{ $t('torrent.properties.tags') }}:
-              <v-chip v-if="torrent?.tags" v-for="tag in torrent.tags" :key="tag" small class="tags white--text caption ml-2">{{ tag }}</v-chip>
-              <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">(no tags)</v-chip>
-            </v-list-item>
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-simple-table>
-        <tbody>
-          <tr id="torrentSavePath">
-            <td :class="commonStyle">
-              {{ $t('torrent.properties.save_path') }}
-            </td>
-            <td>
-              {{ torrent.savePath }}
-            </td>
-          </tr>
-          <tr id="torrentSize">
-            <td :class="commonStyle">
-              Selected Size
-            </td>
-            <td>
-              {{ torrent.size | getDataValue }}
-              {{ torrent.size | getDataUnit }}
-              /
-              {{ torrent.total_size | getDataValue }}
-              {{ torrent.total_size | getDataUnit }}
-            </td>
-          </tr>
-        </tbody>
-      </v-simple-table>
-    </v-row>
-  </v-flex>
+          </td>
+        </tr>
+        <tr id="torrentPieceState">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.pieceStates') }}
+          </td>
+          <td id="pieceStates" class="d-flex">
+            <span class="mr-2 align-center d-flex"> {{ torrent.progress }}% </span>
+            <canvas width="0" height="1" />
+          </td>
+        </tr>
+        <tr id="torrentSavePath">
+          <td :class="commonStyle">
+            {{ $t('torrent.properties.save_path') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.savePath }}
+          </td>
+        </tr>
+        <tr id="torrentHash">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.hash') }}
+          </td>
+          <td>
+            {{ torrent.hash }}
+          </td>
+        </tr>
+        <tr id="torrentSize">
+          <td :class="commonStyle">
+            {{ $t('torrent.properties.size') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.size | getDataValue }}
+            {{ torrent.size | getDataUnit }}
+          </td>
+        </tr>
+        <tr id="torrentTotalSize">
+          <td :class="commonStyle">
+            {{ $t('torrent.properties.total_size') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.total_size | getDataValue }}
+            {{ torrent.total_size | getDataUnit }}
+          </td>
+        </tr>
+        <tr id="torrentTimeActive">
+          <td :class="commonStyle">
+            {{ $t('torrent.properties.time_active') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.time_active }}
+            <span>{{ seedingTime }}</span>
+          </td>
+        </tr>
+        <tr id="torrentDownloaded">
+          <td :class="commonStyle">
+            {{ $t('torrent.downloaded') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.downloaded | getDataValue }}
+            {{ torrent.downloaded | getDataUnit }}
+          </td>
+        </tr>
+        <tr id="torrentUploaded">
+          <td :class="commonStyle">
+            {{ $t('torrent.uploaded') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.uploaded | getDataValue }}
+            {{ torrent.uploaded | getDataUnit }}
+          </td>
+        </tr>
+        <tr id="torrentRatio">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.ratio') }}
+          </td>
+          <td>
+            {{ torrent.ratio }}
+          </td>
+        </tr>
+        <tr id="torrentDlSpeed">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.downloadSpeed') }}
+          </td>
+          <td>
+            {{ torrent.dlspeed | getDataValue }}
+            {{ torrent.dlspeed | getDataUnit }}/s
+          </td>
+        </tr>
+        <tr id="torrentDlSpeedAvg">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.dl_speed_average') | titleCase }}
+          </td>
+          <td>
+            {{ downloadSpeedAvg | getDataValue }}
+            {{ downloadSpeedAvg | getDataUnit }}/s
+          </td>
+        </tr>
+        <tr id="torrentUpSpeed">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.uploadSpeed') }}
+          </td>
+          <td>
+            {{ torrent.upspeed | getDataValue }}
+            {{ torrent.upspeed | getDataUnit }}/s
+          </td>
+        </tr>
+        <tr id="torrentUpSpeedAvg">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.up_speed_average') | titleCase }}
+          </td>
+          <td>
+            {{ uploadSpeedAvg | getDataValue }}
+            {{ uploadSpeedAvg | getDataUnit }}/s
+          </td>
+        </tr>
+        <tr id="torrentEta">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.eta') }}
+          </td>
+          <td>
+            {{ torrent.eta }}
+          </td>
+        </tr>
+        <tr id="torrentPeers">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.peers') }}
+          </td>
+          <td>
+            {{ torrent.num_leechs }}<span :class="commonStyle">/{{ torrent.available_peers }}</span>
+          </td>
+        </tr>
+        <tr id="torrentSeeds">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.seeds') }}
+          </td>
+          <td>
+            {{ torrent.num_seeds }}<span :class="commonStyle">/{{ torrent.available_seeds }}</span>
+          </td>
+        </tr>
+        <tr id="torrentAddedOn">
+          <td :class="commonStyle">
+            {{ $t('torrent.properties.added_on') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.added_on }}
+          </td>
+        </tr>
+        <tr id="torrentCreationDate">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.creation_date') | titleCase }}
+          </td>
+          <td>
+            {{ creationDate }}
+          </td>
+        </tr>
+        <tr id="torrentState">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.status') }}
+          </td>
+          <td>
+            <v-chip small :class="`${torrentStateClass} white--text caption`">
+              {{ torrent.state }}
+            </v-chip>
+          </td>
+        </tr>
+        <tr id="torrentTrackers" v-if="torrent?.tracker">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.trackers') }}
+          </td>
+          <td>
+            <span v-for="trackersPart in splitString(torrent.tracker)" :key="trackersPart">
+              <a v-if="stringContainsUrl(trackersPart)" target="_blank" :href="trackersPart">{{ trackersPart }}</a>
+              <span v-else>{{ trackersPart }}</span>
+            </span>
+          </td>
+        </tr>
+        <tr id="torrentCreatedBy" v-if="createdBy">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.createdBy') }}
+          </td>
+          <td>
+            <span v-for="createdByPart in splitString(createdBy)" :key="createdByPart">
+              <a v-if="stringContainsUrl(createdByPart)" target="_blank" :href="createdByPart">{{ createdByPart }}</a>
+              <span v-else>{{ createdByPart }}</span>
+            </span>
+          </td>
+        </tr>
+
+        <tr id="torrentFLPiecePrio">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.firstLastPiecePriority') }}
+          </td>
+          <td>
+            {{ torrent.f_l_piece_prio }}
+          </td>
+        </tr>
+        <tr id="torrentSeqDl">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.sequentialDownload') }}
+          </td>
+          <td>
+            {{ torrent.seq_dl }}
+          </td>
+        </tr>
+        <tr id="torrentAutoTMM">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.autoTMM') }}
+          </td>
+          <td>
+            {{ torrent.auto_tmm }}
+          </td>
+        </tr>
+        <tr id="torrentRatioLimit">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.shareRatioLimit') }}
+          </td>
+          <td>
+            {{ torrent.ratio_limit | limitToValue }}
+          </td>
+        </tr>
+        <tr id="torrentRatioTimeLimit">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.shareTimeLimit') }}
+          </td>
+          <td>
+            {{ torrent.ratio_time_limit | limitToValue }}
+          </td>
+        </tr>
+        <tr id="torrentDlLimit">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.downloadLimit') }}
+          </td>
+          <td v-if="torrent?.dl_limit > 0">
+            {{ torrent.dl_limit | getDataValue }}
+            {{ torrent.dl_limit | getDataUnit }}<span>/s </span>
+          </td>
+          <td v-else>∞</td>
+        </tr>
+        <tr id="torrentUpLimit">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.uploadLimit') }}
+          </td>
+          <td v-if="torrent?.up_limit > 0">
+            {{ torrent.up_limit | getDataValue }}
+            {{ torrent.up_limit | getDataUnit }}<span>/s </span>
+          </td>
+          <td v-else>∞</td>
+        </tr>
+        <tr id="torrentAvailability">
+          <td :class="commonStyle">
+            {{ $t('torrent.properties.availability') | titleCase }}
+          </td>
+          <td>
+            {{ torrent.availability }}
+          </td>
+        </tr>
+        <tr id="torrentPrivate">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.is_private') | titleCase }}
+          </td>
+          <td>
+            {{ isPrivateTorrent }}
+          </td>
+        </tr>
+        <tr id="torrentPieceCount">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.piece_owned') | titleCase }}
+          </td>
+          <td>{{ torrentPieceOwned }} / {{ torrentPieceCount }}</td>
+        </tr>
+        <tr id="torrentPieceSize">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.piece_size') | titleCase }}
+          </td>
+          <td>
+            {{ torrentPieceSize | getDataValue }}
+            {{ torrentPieceSize | getDataUnit }}
+          </td>
+        </tr>
+        <tr id="torrentWastedSize">
+          <td :class="commonStyle">
+            {{ $t('modals.detail.pageInfo.wasted_size') | titleCase }}
+          </td>
+          <td>
+            {{ wastedSize | getDataValue }}
+            {{ wastedSize | getDataUnit }}
+          </td>
+        </tr>
+      </tbody>
+    </v-simple-table>
+  </v-card>
 </template>
 
 <script lang="ts">
-import dayjs from "dayjs";
-import { FullScreenModal } from "@/mixins";
-import qbit from "@/services/qbit";
-import { getDomainBody, splitByUrl, stringContainsUrl } from "@/helpers";
-import { defineComponent } from "vue";
-import { Torrent } from "@/models";
-import { mapState } from "vuex";
-import { mdiClose, mdiContentSave, mdiPencil } from "@mdi/js";
-import { TorrentState } from "@/enums/vuetorrent";
+import dayjs from 'dayjs'
+import { FullScreenModal } from '@/mixins'
+import qbit from '@/services/qbit'
+import { splitByUrl, stringContainsUrl } from '@/helpers'
+import { defineComponent } from 'vue'
+import { Torrent } from '@/models'
+import { mapState } from 'vuex'
 
 export default defineComponent({
   name: 'Info',
@@ -107,11 +341,7 @@ export default defineComponent({
       torrentPieceOwned: 0,
       torrentPieceCount: 0,
       wastedSize: 0,
-      uploadSpeedAvg: 0,
-      mdiClose,
-      mdiPencil,
-      mdiContentSave,
-      TorrentState
+      uploadSpeedAvg: 0
     }
   },
   async mounted() {
@@ -136,7 +366,6 @@ export default defineComponent({
     }
   },
   methods: {
-    getDomainBody,
     async getTorrentProperties() {
       const props = await qbit.getTorrentProperties(this.torrent?.hash as string)
       this.comment = props.comment
@@ -152,7 +381,7 @@ export default defineComponent({
       this.uploadSpeedAvg = props.up_speed_avg
     },
     async renderTorrentPieceStates() {
-      const canvas: HTMLCanvasElement | null = document.querySelector('canvas#pieceStates')
+      const canvas: HTMLCanvasElement | null = document.querySelector('#pieceStates canvas')
       if (canvas === null) return
 
       const files = await qbit.getTorrentFiles(this.torrent?.hash as string)
@@ -214,14 +443,6 @@ export default defineComponent({
     },
     splitString(string: string) {
       return splitByUrl(string)
-    },
-    async copyHash() {
-      try {
-        await navigator.clipboard.writeText(this.torrent?.hash as string);
-        console.log('Content copied to clipboard');
-      } catch (err) {
-        console.error('Failed to copy: ', err);
-      }
     }
   }
 })
@@ -246,9 +467,13 @@ export default defineComponent({
   width: 20%;
 }
 
-canvas#pieceStates {
-  height: 50%;
-  width: 100%;
-  border: 1px dotted;
+#pieceStates {
+  display: block;
+
+  canvas {
+    height: 100%;
+    width: 75%;
+    border: 1px dotted;
+  }
 }
 </style>

--- a/src/components/TorrentDetail/Tabs/Info.vue
+++ b/src/components/TorrentDetail/Tabs/Info.vue
@@ -2,66 +2,12 @@
   <v-card flat>
     <v-simple-table>
       <tbody>
-        <tr id="torrentName">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.torrentTitle') }}
-          </td>
-          <td>
-            {{ torrent.name }}
-          </td>
-        </tr>
-        <tr id="torrentComment" v-if="comment">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.comments') | titleCase }}
-          </td>
-          <td>
-            <span v-for="commentPart in splitString(comment)" :key="commentPart">
-              <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
-              <span v-else>{{ commentPart }}</span>
-            </span>
-          </td>
-        </tr>
-        <tr id="torrentPieceState">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.pieceStates') }}
-          </td>
-          <td id="pieceStates" class="d-flex">
-            <span class="mr-2 align-center d-flex"> {{ torrent.progress }}% </span>
-            <canvas width="0" height="1" />
-          </td>
-        </tr>
         <tr id="torrentSavePath">
           <td :class="commonStyle">
             {{ $t('torrent.properties.save_path') | titleCase }}
           </td>
           <td>
             {{ torrent.savePath }}
-          </td>
-        </tr>
-        <tr id="torrentHash">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.hash') }}
-          </td>
-          <td>
-            {{ torrent.hash }}
-          </td>
-        </tr>
-        <tr id="torrentSize">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.size') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.size | getDataValue }}
-            {{ torrent.size | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentTotalSize">
-          <td :class="commonStyle">
-            {{ $t('torrent.properties.total_size') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.total_size | getDataValue }}
-            {{ torrent.total_size | getDataUnit }}
           </td>
         </tr>
         <tr id="torrentTimeActive">
@@ -71,68 +17,6 @@
           <td>
             {{ torrent.time_active }}
             <span>{{ seedingTime }}</span>
-          </td>
-        </tr>
-        <tr id="torrentDownloaded">
-          <td :class="commonStyle">
-            {{ $t('torrent.downloaded') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.downloaded | getDataValue }}
-            {{ torrent.downloaded | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentUploaded">
-          <td :class="commonStyle">
-            {{ $t('torrent.uploaded') | titleCase }}
-          </td>
-          <td>
-            {{ torrent.uploaded | getDataValue }}
-            {{ torrent.uploaded | getDataUnit }}
-          </td>
-        </tr>
-        <tr id="torrentRatio">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.ratio') }}
-          </td>
-          <td>
-            {{ torrent.ratio }}
-          </td>
-        </tr>
-        <tr id="torrentDlSpeed">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.downloadSpeed') }}
-          </td>
-          <td>
-            {{ torrent.dlspeed | getDataValue }}
-            {{ torrent.dlspeed | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentDlSpeedAvg">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.dl_speed_average') | titleCase }}
-          </td>
-          <td>
-            {{ downloadSpeedAvg | getDataValue }}
-            {{ downloadSpeedAvg | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentUpSpeed">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.uploadSpeed') }}
-          </td>
-          <td>
-            {{ torrent.upspeed | getDataValue }}
-            {{ torrent.upspeed | getDataUnit }}/s
-          </td>
-        </tr>
-        <tr id="torrentUpSpeedAvg">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.up_speed_average') | titleCase }}
-          </td>
-          <td>
-            {{ uploadSpeedAvg | getDataValue }}
-            {{ uploadSpeedAvg | getDataUnit }}/s
           </td>
         </tr>
         <tr id="torrentEta">
@@ -173,16 +57,6 @@
           </td>
           <td>
             {{ creationDate }}
-          </td>
-        </tr>
-        <tr id="torrentState">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.status') }}
-          </td>
-          <td>
-            <v-chip small :class="`${torrentStateClass} white--text caption`">
-              {{ torrent.state }}
-            </v-chip>
           </td>
         </tr>
         <tr id="torrentTrackers" v-if="torrent?.tracker">
@@ -284,21 +158,6 @@
             {{ isPrivateTorrent }}
           </td>
         </tr>
-        <tr id="torrentPieceCount">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.piece_owned') | titleCase }}
-          </td>
-          <td>{{ torrentPieceOwned }} / {{ torrentPieceCount }}</td>
-        </tr>
-        <tr id="torrentPieceSize">
-          <td :class="commonStyle">
-            {{ $t('modals.detail.pageInfo.piece_size') | titleCase }}
-          </td>
-          <td>
-            {{ torrentPieceSize | getDataValue }}
-            {{ torrentPieceSize | getDataUnit }}
-          </td>
-        </tr>
         <tr id="torrentWastedSize">
           <td :class="commonStyle">
             {{ $t('modals.detail.pageInfo.wasted_size') | titleCase }}
@@ -335,13 +194,8 @@ export default defineComponent({
       comment: '',
       createdBy: '',
       creationDate: '',
-      downloadSpeedAvg: 0,
       isPrivateTorrent: false,
-      torrentPieceSize: 0,
-      torrentPieceOwned: 0,
-      torrentPieceCount: 0,
-      wastedSize: 0,
-      uploadSpeedAvg: 0
+      wastedSize: 0
     }
   },
   async mounted() {
@@ -372,13 +226,8 @@ export default defineComponent({
       this.createdBy = props.created_by
       // @ts-expect-error: TS2339: Property 'dateFormat' does not exist on type 'never'.
       this.creationDate = dayjs(props.creation_date * 1000).format(this.webuiSettings.dateFormat)
-      this.downloadSpeedAvg = props.dl_speed_avg
       this.isPrivateTorrent = props.is_private
-      this.torrentPieceSize = props.piece_size
-      this.torrentPieceOwned = props.pieces_have
-      this.torrentPieceCount = props.pieces_num
       this.wastedSize = props.total_wasted
-      this.uploadSpeedAvg = props.up_speed_avg
     },
     async renderTorrentPieceStates() {
       const canvas: HTMLCanvasElement | null = document.querySelector('#pieceStates canvas')

--- a/src/components/TorrentDetail/Tabs/Overview.vue
+++ b/src/components/TorrentDetail/Tabs/Overview.vue
@@ -15,7 +15,7 @@
           <v-card-text>
             <v-row>
               <v-col cols="4" md="3">
-                <v-progress-circular v-if="torrent?.state === TorrentState.METADATA" indeterminate :size="100" color="torrent-metadata">Fetching...</v-progress-circular>
+                <v-progress-circular v-if="torrent?.state === TorrentState.METADATA" indeterminate :size="100" color="torrent-metadata">{{ $t('modals.detail.pageOverview.fetchingMetadata') }}</v-progress-circular>
                 <v-progress-circular v-else-if="torrent?.progress === 100" :size="100" :width="15" :value="100" color="torrent-seeding">
                   <v-icon color="torrent-seeding">{{ mdiCheck }}</v-icon>
                 </v-progress-circular>
@@ -49,18 +49,18 @@
               </v-col>
               <v-col cols="6">
                 {{ $t('torrent.properties.category') }}:
-                <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : '(no cat)' }}</v-chip>
+                <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : $t('navbar.filters.uncategorized') }}</v-chip>
               </v-col>
             </v-row>
             <v-row>
               <v-col cols="6">
                 {{ $t('torrent.properties.tracker') }}:
-                <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : '(no tracker)' }}</v-chip>
+                <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : $t('navbar.filters.untracked') }}</v-chip>
               </v-col>
               <v-col cols="6">
                 {{ $t('torrent.properties.tags') }}:
                 <v-chip v-if="torrent?.tags" v-for="tag in torrent.tags" :key="tag" small class="tags white--text caption ml-2">{{ tag }}</v-chip>
-                <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">(no tags)</v-chip>
+                <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">{{ $t('navbar.filters.untagged') }}</v-chip>
               </v-col>
             </v-row>
             <v-row>
@@ -85,11 +85,11 @@
             </v-row>
             <v-row>
               <v-col cols="6">
-                {{ $t('modals.detail.pageOverview.dl_speed_average') }}:<br/>
+                {{ $t('modals.detail.pageOverview.dlSpeedAverage') }}:<br/>
                 {{ downloadSpeedAvg | networkSpeed }}
               </v-col>
               <v-col cols="6">
-                {{ $t('modals.detail.pageOverview.up_speed_average') }}:<br/>
+                {{ $t('modals.detail.pageOverview.upSpeedAverage') }}:<br/>
                 {{ uploadSpeedAvg | networkSpeed }}
               </v-col>
             </v-row>

--- a/src/components/TorrentDetail/Tabs/Overview.vue
+++ b/src/components/TorrentDetail/Tabs/Overview.vue
@@ -1,0 +1,228 @@
+<template>
+  <v-flex>
+    <v-row>
+      <v-col cols="6">
+        <v-card flat>
+          <v-card-title>{{ torrent.name }}</v-card-title>
+          <v-card-subtitle>
+            <span v-for="commentPart in splitString(comment)" :key="commentPart">
+              <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
+              <span v-else>{{ commentPart }}</span>
+            </span>
+            <v-btn text @click="copyHash">{{ torrent.hash }}</v-btn>
+          </v-card-subtitle>
+          <v-card-text>
+            <v-row>
+              <v-col cols="3">
+                <v-progress-circular v-if="torrent?.state === TorrentState.METADATA" indeterminate :size="100" color="torrent-metadata">Fetching...</v-progress-circular>
+                <v-progress-circular v-else :rotate="-90" :size="100" :width="15" :value="torrent?.progress ?? 0" color="accent">{{ torrent.progress ?? 0 }} %</v-progress-circular>
+              </v-col>
+              <v-col cols="9" class="d-flex align-center justify-center">
+                <canvas id="pieceStates" width="0" height="1" />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="6">
+        <v-card flat>
+          <v-card-text>
+            <v-list-item>
+              {{ $t('modals.detail.pageInfo.status') }}:
+              <v-chip small :class="`${torrentStateClass} white--text caption ml-2`">{{ torrent.state }}</v-chip>
+            </v-list-item>
+            <v-list-item>
+              {{ $t('torrent.properties.category') }}:
+              <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : '(no cat)' }}</v-chip>
+            </v-list-item>
+            <v-list-item>
+              {{ $t('torrent.properties.tracker') }}:
+              <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : '(no tracker)' }}</v-chip>
+            </v-list-item>
+            <v-list-item>
+              {{ $t('torrent.properties.tags') }}:
+              <v-chip v-if="torrent?.tags" v-for="tag in torrent.tags" :key="tag" small class="tags white--text caption ml-2">{{ tag }}</v-chip>
+              <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">(no tags)</v-chip>
+            </v-list-item>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-flex>
+</template>
+
+<script lang="ts">
+import dayjs from "dayjs";
+import { FullScreenModal } from "@/mixins";
+import qbit from "@/services/qbit";
+import { getDomainBody, splitByUrl, stringContainsUrl } from "@/helpers";
+import { defineComponent } from "vue";
+import { Torrent } from "@/models";
+import { mapState } from "vuex";
+import { mdiClose, mdiContentSave, mdiPencil } from "@mdi/js";
+import { TorrentState } from "@/enums/vuetorrent";
+
+export default defineComponent({
+  name: 'Overflow',
+  mixins: [FullScreenModal],
+  props: {
+    torrent: Torrent,
+    isActive: Boolean
+  },
+  data() {
+    return {
+      commonStyle: 'caption',
+      comment: '',
+      createdBy: '',
+      creationDate: '',
+      downloadSpeedAvg: 0,
+      isPrivateTorrent: false,
+      torrentPieceSize: 0,
+      torrentPieceOwned: 0,
+      torrentPieceCount: 0,
+      wastedSize: 0,
+      uploadSpeedAvg: 0,
+      mdiClose,
+      mdiPencil,
+      mdiContentSave,
+      TorrentState
+    }
+  },
+  async mounted() {
+    await this.getTorrentProperties()
+    await this.renderTorrentPieceStates()
+  },
+  computed: {
+    ...mapState(['webuiSettings']),
+    seedingTime() {
+      if (!this.torrent?.seeding_time) return ''
+
+      const content = this.$t('modals.detail.pageInfo.seededFor').toString().replace('$0', this.torrent.seeding_time)
+      return `(${content})`
+    },
+    torrentStateClass() {
+      return this.torrent?.state ? this.torrent.state.toLowerCase() : ''
+    }
+  },
+  watch: {
+    torrent() {
+      this.renderTorrentPieceStates()
+    }
+  },
+  methods: {
+    getDomainBody,
+    async getTorrentProperties() {
+      const props = await qbit.getTorrentProperties(this.torrent?.hash as string)
+      this.comment = props.comment
+      this.createdBy = props.created_by
+      // @ts-expect-error: TS2339: Property 'dateFormat' does not exist on type 'never'.
+      this.creationDate = dayjs(props.creation_date * 1000).format(this.webuiSettings.dateFormat)
+      this.downloadSpeedAvg = props.dl_speed_avg
+      this.isPrivateTorrent = props.is_private
+      this.torrentPieceSize = props.piece_size
+      this.torrentPieceOwned = props.pieces_have
+      this.torrentPieceCount = props.pieces_num
+      this.wastedSize = props.total_wasted
+      this.uploadSpeedAvg = props.up_speed_avg
+    },
+    async renderTorrentPieceStates() {
+      const canvas: HTMLCanvasElement | null = document.querySelector('canvas#pieceStates')
+      if (canvas === null) return
+
+      const files = await qbit.getTorrentFiles(this.torrent?.hash as string)
+      const pieces = await qbit.getTorrentPieceStates(this.torrent?.hash as string)
+      if (!pieces) return
+
+      // Source: https://github.com/qbittorrent/qBittorrent/blob/6229b817300344759139d2fedbd59651065a561d/src/webui/www/private/scripts/prop-general.js#L230
+      canvas.width = pieces.length
+      const ctx = canvas.getContext('2d') as CanvasRenderingContext2D
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      // Group contiguous colors together and draw as a single rectangle
+      let color = ''
+      let rectWidth = 1
+
+      for (let i = 0; i < pieces.length; ++i) {
+        const status = pieces[i]
+        let newColor = ''
+
+        if (status === 1)
+            // requested / downloading
+          newColor = this.$vuetify.theme.currentTheme['torrent-downloading'] as string
+        else if (status === 2)
+            // already downloaded
+          newColor = this.$vuetify.theme.currentTheme['torrent-done'] as string
+        else {
+          // pending download
+          const selected_piece_ranges = files.filter(file => file.priority !== 0).map(file => file.piece_range)
+          for (const [min_piece_range, max_piece_range] of selected_piece_ranges) {
+            if (i > min_piece_range && i < max_piece_range) {
+              newColor = this.$vuetify.theme.currentTheme['torrent-paused'] as string
+              break
+            }
+          }
+        }
+
+        if (newColor === color) {
+          ++rectWidth
+          continue
+        }
+
+        if (color !== '') {
+          ctx.fillStyle = color
+          ctx.fillRect(i - rectWidth, 0, rectWidth, canvas.height)
+        }
+
+        rectWidth = 1
+        color = newColor
+      }
+
+      // Fill a rect at the end of the canvas if one is needed
+      if (color !== '') {
+        ctx.fillStyle = color
+        ctx.fillRect(pieces.length - rectWidth, 0, rectWidth, canvas.height)
+      }
+    },
+    stringContainsUrl(string: string) {
+      return stringContainsUrl(string)
+    },
+    splitString(string: string) {
+      return splitByUrl(string)
+    },
+    async copyHash() {
+      try {
+        await navigator.clipboard.writeText(this.torrent?.hash as string);
+        console.log('Content copied to clipboard');
+      } catch (err) {
+        console.error('Failed to copy: ', err);
+      }
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+:deep(.v-data-table thead th),
+:deep(.v-data-table tbody td) {
+  padding: 0 !important;
+  height: 3em;
+
+  &:first-child {
+    padding: 0 0 0 8px !important;
+  }
+
+  &:last-child {
+    padding-right: 8px !important;
+  }
+}
+
+:deep(.v-data-table tbody td.caption) {
+  width: 20%;
+}
+
+canvas#pieceStates {
+  height: 50%;
+  width: 100%;
+  border: 1px dotted;
+}
+</style>

--- a/src/components/TorrentDetail/Tabs/Overview.vue
+++ b/src/components/TorrentDetail/Tabs/Overview.vue
@@ -1,49 +1,98 @@
 <template>
   <v-flex>
     <v-row>
-      <v-col cols="6">
+      <v-col cols="12" md="6">
         <v-card flat>
           <v-card-title>{{ torrent.name }}</v-card-title>
           <v-card-subtitle>
-            <span v-for="commentPart in splitString(comment)" :key="commentPart">
+            <div v-for="commentPart in splitString(comment)" :key="commentPart">
               <a v-if="stringContainsUrl(commentPart)" target="_blank" :href="commentPart">{{ commentPart }}</a>
               <span v-else>{{ commentPart }}</span>
-            </span>
-            <v-btn text @click="copyHash">{{ torrent.hash }}</v-btn>
+            </div>
+            {{ torrent.hash }}
+            <v-btn rounded @click="copyHash">{{ $t('rightClick.copy') }}</v-btn>
           </v-card-subtitle>
           <v-card-text>
             <v-row>
-              <v-col cols="3">
+              <v-col cols="4" md="3">
                 <v-progress-circular v-if="torrent?.state === TorrentState.METADATA" indeterminate :size="100" color="torrent-metadata">Fetching...</v-progress-circular>
+                <v-progress-circular v-else-if="torrent?.progress === 100" :size="100" :width="15" :value="100" color="torrent-seeding">
+                  <v-icon color="torrent-seeding">{{ mdiCheck }}</v-icon>
+                </v-progress-circular>
                 <v-progress-circular v-else :rotate="-90" :size="100" :width="15" :value="torrent?.progress ?? 0" color="accent">{{ torrent.progress ?? 0 }} %</v-progress-circular>
               </v-col>
-              <v-col cols="9" class="d-flex align-center justify-center">
-                <canvas id="pieceStates" width="0" height="1" />
+              <v-col cols="8" md="9" class="d-flex align-center justify-center flex-column">
+                <div>
+                  <canvas id="pieceStates" width="0" height="1" />
+                </div>
+                <div>
+                  <span>{{ torrentPieceOwned }} / {{ torrentPieceCount }} ({{ torrentPieceSize | getDataValue }} {{ torrentPieceSize | getDataUnit }})</span>
+                </div>
+                <div>
+                  <v-icon>{{ mdiArrowDown }}</v-icon>
+                  {{ torrent?.dlspeed | networkSpeed }}
+                  <v-icon>{{ mdiArrowUp }}</v-icon>
+                  {{ torrent?.upspeed | networkSpeed }}
+                </div>
               </v-col>
             </v-row>
           </v-card-text>
         </v-card>
       </v-col>
-      <v-col cols="6">
+      <v-col cols="12" md="6">
         <v-card flat>
           <v-card-text>
-            <v-list-item>
-              {{ $t('modals.detail.pageInfo.status') }}:
-              <v-chip small :class="`${torrentStateClass} white--text caption ml-2`">{{ torrent.state }}</v-chip>
-            </v-list-item>
-            <v-list-item>
-              {{ $t('torrent.properties.category') }}:
-              <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : '(no cat)' }}</v-chip>
-            </v-list-item>
-            <v-list-item>
-              {{ $t('torrent.properties.tracker') }}:
-              <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : '(no tracker)' }}</v-chip>
-            </v-list-item>
-            <v-list-item>
-              {{ $t('torrent.properties.tags') }}:
-              <v-chip v-if="torrent?.tags" v-for="tag in torrent.tags" :key="tag" small class="tags white--text caption ml-2">{{ tag }}</v-chip>
-              <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">(no tags)</v-chip>
-            </v-list-item>
+            <v-row>
+              <v-col cols="6">
+                {{ $t('modals.detail.pageOverview.status') }}:
+                <v-chip small :class="`${torrentStateClass} white--text caption ml-2`">{{ torrent.state }}</v-chip>
+              </v-col>
+              <v-col cols="6">
+                {{ $t('torrent.properties.category') }}:
+                <v-chip small class="upload white--text caption ml-2">{{ torrent.category.length ? torrent.category : '(no cat)' }}</v-chip>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="6">
+                {{ $t('torrent.properties.tracker') }}:
+                <v-chip small class="moving white--text caption ml-2">{{ this.torrent?.tracker ? getDomainBody(this.torrent?.tracker) : '(no tracker)' }}</v-chip>
+              </v-col>
+              <v-col cols="6">
+                {{ $t('torrent.properties.tags') }}:
+                <v-chip v-if="torrent?.tags" v-for="tag in torrent.tags" :key="tag" small class="tags white--text caption ml-2">{{ tag }}</v-chip>
+                <v-chip v-if="!torrent?.tags || torrent.tags.length === 0" small class="tags white--text caption ml-2">(no tags)</v-chip>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="6">
+                {{ $t('modals.detail.pageOverview.selectedFileSize') }}:<br/>
+                {{ torrent?.size | getDataValue }} {{ torrent?.size | getDataUnit }} / {{ torrent?.total_size | getDataValue }} {{ torrent?.total_size | getDataUnit }}
+              </v-col>
+              <v-col cols="6">
+                {{ $t('ratio') }}:<br/>
+                {{ torrent?.ratio }}
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="6">
+                {{ $t('downloaded') }}:<br/>
+                {{ torrent?.downloaded | getDataValue }} {{ torrent?.downloaded | getDataUnit }}
+              </v-col>
+              <v-col cols="6">
+                {{ $t('uploaded') }}:<br/>
+                {{ torrent?.uploaded | getDataValue }} {{ torrent?.uploaded | getDataUnit }}
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="6">
+                {{ $t('modals.detail.pageOverview.dl_speed_average') }}:<br/>
+                {{ downloadSpeedAvg | networkSpeed }}
+              </v-col>
+              <v-col cols="6">
+                {{ $t('modals.detail.pageOverview.up_speed_average') }}:<br/>
+                {{ uploadSpeedAvg | networkSpeed }}
+              </v-col>
+            </v-row>
           </v-card-text>
         </v-card>
       </v-col>
@@ -59,7 +108,7 @@ import { getDomainBody, splitByUrl, stringContainsUrl } from "@/helpers";
 import { defineComponent } from "vue";
 import { Torrent } from "@/models";
 import { mapState } from "vuex";
-import { mdiClose, mdiContentSave, mdiPencil } from "@mdi/js";
+import { mdiClose, mdiContentSave, mdiPencil, mdiArrowDown, mdiArrowUp, mdiCheck } from "@mdi/js";
 import { TorrentState } from "@/enums/vuetorrent";
 
 export default defineComponent({
@@ -80,11 +129,13 @@ export default defineComponent({
       torrentPieceSize: 0,
       torrentPieceOwned: 0,
       torrentPieceCount: 0,
-      wastedSize: 0,
       uploadSpeedAvg: 0,
       mdiClose,
       mdiPencil,
       mdiContentSave,
+      mdiArrowUp,
+      mdiArrowDown,
+      mdiCheck,
       TorrentState
     }
   },
@@ -106,7 +157,10 @@ export default defineComponent({
   },
   watch: {
     torrent() {
-      this.renderTorrentPieceStates()
+      this.getTorrentProperties()
+      if (this.torrentPieceCount < 5000) {
+        this.renderTorrentPieceStates()
+      }
     }
   },
   methods: {
@@ -122,7 +176,6 @@ export default defineComponent({
       this.torrentPieceSize = props.piece_size
       this.torrentPieceOwned = props.pieces_have
       this.torrentPieceCount = props.pieces_num
-      this.wastedSize = props.total_wasted
       this.uploadSpeedAvg = props.up_speed_avg
     },
     async renderTorrentPieceStates() {
@@ -192,9 +245,9 @@ export default defineComponent({
     async copyHash() {
       try {
         await navigator.clipboard.writeText(this.torrent?.hash as string);
-        console.log('Content copied to clipboard');
+        this.$toast.success(this.$t('toast.copySuccess').toString())
       } catch (err) {
-        console.error('Failed to copy: ', err);
+        this.$toast.error(this.$t('toast.copyNotSupported').toString())
       }
     }
   }
@@ -221,8 +274,12 @@ export default defineComponent({
 }
 
 canvas#pieceStates {
-  height: 50%;
+  height: 100%;
   width: 100%;
   border: 1px dotted;
+}
+
+.v-card__title {
+  word-break: normal;
 }
 </style>

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -35,10 +35,6 @@ export function formatProgress(progress: number): string {
 Vue.filter('progress', formatProgress)
 
 export function formatNetworkSpeed(speed: number): string | null {
-  if (speed === 0) {
-    return null
-  }
-
   return `${formatSize(speed)}/s`
 }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -650,17 +650,15 @@
       "tabTitlePeers": "Peers",
       "tabTitleContent": "Content",
       "tabTitleTagsCategories": "Tags & Categories",
+      "pageOverview": {
+        "selectedFileSize": "Selected Files' Size",
+        "dl_speed_average": "Download Speed Average",
+        "up_speed_average": "Upload Speed Average"
+      },
       "pageInfo": {
-        "pieceStates": "Progress",
-        "torrentTitle": "Torrent title",
-        "hash": "Hash",
-        "ratio": "Ratio",
-        "downloadSpeed": "DL Speed",
-        "uploadSpeed": "UP Speed",
         "eta": "ETA",
         "peers": "Peers",
         "seeds": "Seeds",
-        "status": "Status",
         "trackers": "Trackers",
         "comments": "Comments",
         "createdBy": "Created By",
@@ -673,11 +671,7 @@
         "downloadLimit": "Download Limit",
         "uploadLimit": "Upload Limit",
         "creation_date": "Creation Date",
-        "dl_speed_average": "Download Speed Average",
-        "up_speed_average": "Upload Speed Average",
         "is_private": "Torrent Private",
-        "piece_owned": "Collected pieces",
-        "piece_size": "Piece Size",
         "wasted_size": "Wasted"
       },
       "pagePeers": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -644,6 +644,7 @@
     },
     "detail": {
       "title": "Torrent Detail",
+      "tabTitleOverview": "Overview",
       "tabTitleInfo": "Info",
       "tabTitleTrackers": "Trackers",
       "tabTitlePeers": "Peers",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -138,6 +138,7 @@
       "moving": "Moving",
       "uncategorized": "(Uncategorized)",
       "untagged": "(Untagged)",
+      "untracked": "(Untracked)",
       "not_working": "(Not Working)"
     },
     "active_tooltip": {
@@ -651,9 +652,10 @@
       "tabTitleContent": "Content",
       "tabTitleTagsCategories": "Tags & Categories",
       "pageOverview": {
+        "fetchingMetadata": "Fetching...",
         "selectedFileSize": "Selected Files' Size",
-        "dl_speed_average": "Download Speed Average",
-        "up_speed_average": "Upload Speed Average"
+        "dlSpeedAverage": "Download Speed Average",
+        "upSpeedAverage": "Upload Speed Average"
       },
       "pageInfo": {
         "eta": "ETA",

--- a/src/models/Torrent.ts
+++ b/src/models/Torrent.ts
@@ -100,7 +100,7 @@ export default class Torrent {
     this.size = data.size
     this.state = this.formatState(data.state)
     this.super_seeding = data.super_seeding
-    this.tags = data.tags.length > 0 ? data.tags.split(', ').map(t => t.trim()) : null
+    this.tags = data.tags.length > 0 ? data.tags.split(', ').map(t => t.trim()) : []
     this.time_active = dayjs.duration(data.time_active, 'seconds').format(durationFormat)
     this.total_size = data.total_size
     this.tracker = data.tracker

--- a/src/views/TorrentDetail.vue
+++ b/src/views/TorrentDetail.vue
@@ -18,6 +18,9 @@
     <v-row class="ma-0 pa-0">
       <v-tabs v-model="tab" align-with-title show-arrows background-color="primary">
         <v-tabs-slider color="white" />
+        <v-tab class="white--text" href="#overview">
+          <h4>{{ $t('modals.detail.tabTitleOverview') }}</h4>
+        </v-tab>
         <v-tab class="white--text" href="#info">
           <h4>{{ $t('modals.detail.tabTitleInfo') }}</h4>
         </v-tab>
@@ -37,6 +40,9 @@
 
       <v-card-text class="pa-0">
         <v-tabs-items v-model="tab" touchless>
+          <v-tab-item eager value="overview">
+            <Overview v-if="torrent" :is-active="tab === 'overview'" :torrent="torrent" />
+          </v-tab-item>
           <v-tab-item eager value="info">
             <Info v-if="torrent" :is-active="tab === 'info'" :torrent="torrent" />
           </v-tab-item>
@@ -58,14 +64,15 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { mapGetters } from 'vuex'
 import { Content, Info, DetailPeers, Trackers, TorrentTagsAndCategories } from '../components/TorrentDetail/Tabs'
 import { mdiClose } from '@mdi/js'
+import Overview from "@/components/TorrentDetail/Tabs/Overview.vue";
 
 export default {
   name: 'TorrentDetail',
-  components: { Content, Info, DetailPeers, Trackers, TorrentTagsAndCategories },
+  components: { Overview, Content, Info, DetailPeers, Trackers, TorrentTagsAndCategories },
   data() {
     return {
       tab: null,
@@ -77,7 +84,7 @@ export default {
     torrent() {
       return this.getTorrent(this.hash)
     },
-    hash() {
+    hash(): string {
       return this.$route.params.hash
     }
   },
@@ -93,7 +100,7 @@ export default {
     close() {
       this.$router.back()
     },
-    handleKeyboardShortcut(e) {
+    handleKeyboardShortcut(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         this.close()
       }


### PR DESCRIPTION
# Add Overview tab [perf]

Adds a user-friendly tab to better visualize essential data in a dashboard-like style.

Desktop:
![image](https://github.com/WDaan/VueTorrent/assets/22910497/8621deae-e289-4e95-83ec-f22d80ac1456)

Mobile:
![image](https://github.com/WDaan/VueTorrent/assets/22910497/8d07b2c5-79ee-4e01-a2b5-53a4f87bdebb)

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
