### PR TITLE
fix: searchFilter is sometimes null

### DIFF
--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -16,7 +16,7 @@
           <div class="d-flex flex-column align-start" style="width: 100%; row-gap: 8px">
             <v-tooltip bottom open-delay="400">
               <template #activator="{ on }">
-                <v-chip v-if="dashboard.searchFilter.length > 0" small class="white--text caption">
+                <v-chip v-if="dashboard.searchFilter?.length > 0" small class="white--text caption">
                   {{ $t('navbar.active_filter.search_filter').replace('$0', dashboard.searchFilter) }}
                 </v-chip>
               </template>
@@ -124,7 +124,7 @@ export default {
       return this.getTorrentCountString()
     },
     filterCount() {
-      return (this.dashboard.searchFilter.length > 0) + (this.sort_options.filter !== null) + (this.sort_options.category !== null) + (this.sort_options.tag !== null) + (this.sort_options.tracker !== null)
+      return (this.dashboard.searchFilter?.length > 0) + (this.sort_options.filter !== null) + (this.sort_options.category !== null) + (this.sort_options.tag !== null) + (this.sort_options.tracker !== null)
     }
   },
   created() {


### PR DESCRIPTION
# searchFilter is sometimes null [fix]

Add null check to prevent speed dial from being stuck in errored state

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
