### PR TITLE
chore: AddModal button not present on desktop

### DIFF
--- a/src/components/Navbar/TopActions.vue
+++ b/src/components/Navbar/TopActions.vue
@@ -1,5 +1,15 @@
 <template>
   <div :class="mobile ? '' : 'flex-shrink-0 ml-0'">
+    <v-tooltip v-if="!mobile" bottom open-delay="400">
+      <template #activator="{ on }">
+        <v-btn small fab :text="!mobile" class="mr-0 ml-0" :aria-label="$t('navbar.topActions.addTorrent')" v-on="on" @click="createModal('AddModal')">
+          <v-icon color="grey">
+            {{ mdiPlus }}
+          </v-icon>
+        </v-btn>
+      </template>
+      <span> {{ $t('navbar.topActions.addTorrent') }}</span>
+    </v-tooltip>
     <v-tooltip bottom open-delay="400">
       <template #activator="{ on }">
         <v-btn small fab :text="!mobile" class="mr-0 ml-0" :aria-label="$t('navbar.topActions.resumeSelected')" v-on="on" @click="resumeTorrents">
@@ -116,9 +126,6 @@ export default {
       if (!this.selected_torrents.length) return
 
       return this.createModal('ConfirmDeleteModal')
-    },
-    addModal(name) {
-      this.createModal(name)
     },
     goToSearch() {
       if (this.$route.name !== 'search') this.$router.push({ name: 'search' })

--- a/src/components/Navbar/TopMenu.vue
+++ b/src/components/Navbar/TopMenu.vue
@@ -40,11 +40,6 @@ export default {
       mdiClose,
       mdiPlus
     }
-  },
-  methods: {
-    addModal(name) {
-      this.createModal(name)
-    }
   }
 }
 </script>


### PR DESCRIPTION
# AddModal button not present on desktop [fix]

#927 introduced a bug where the add torrent button were missing on desktop

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
