### PR TITLE
fix: light theme handling in logs view

### DIFF
--- a/src/views/Logs.vue
+++ b/src/views/Logs.vue
@@ -150,16 +150,33 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-.logtype-normal {
-  color: white !important;
+.theme--dark {
+  .logtype-normal {
+    color: white !important;
+  }
+  .logtype-info {
+    color: grey !important;
+  }
+  .logtype-warning {
+    color: darkgoldenrod !important;
+  }
+  .logtype-critical {
+    color: darkred !important;
+  }
 }
-.logtype-info {
-  color: grey !important;
-}
-.logtype-warning {
-  color: darkgoldenrod !important;
-}
-.logtype-critical {
-  color: darkred !important;
+
+.theme--light {
+  .logtype-normal {
+    color: black !important;
+  }
+  .logtype-info {
+    color: grey !important;
+  }
+  .logtype-warning {
+    color: goldenrod !important;
+  }
+  .logtype-critical {
+    color: red !important;
+  }
 }
 </style>


### PR DESCRIPTION
# light theme handling in logs view [fix]

Fix normal logs being white on a white background while using light theme.
Fixes #936 

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
