### PR TITLE
perf(overview): Use selected file count instead of total file count

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -225,7 +225,7 @@
     },
     "logs": {
       "title": "qBittorrent Logs",
-      "table":  {
+      "table": {
         "id": "Log ID",
         "type": "Log Level",
         "message": "Message",
@@ -659,7 +659,7 @@
         "selectedFileSize": "Selected Files' Size",
         "dlSpeedAverage": "Download Speed Average",
         "upSpeedAverage": "Upload Speed Average",
-        "fileCount": "File Count"
+        "fileCount": "Selected Files"
       },
       "pageInfo": {
         "eta": "ETA",

--- a/src/lang/zh-hant.json
+++ b/src/lang/zh-hant.json
@@ -225,7 +225,7 @@
     },
     "logs": {
       "title": "qBittorrent 日誌",
-      "table":  {
+      "table": {
         "id": "日誌 ID",
         "type": "日誌等級",
         "message": "訊息",
@@ -658,8 +658,7 @@
         "fetchingMetadata": "正在抓取...",
         "selectedFileSize": "選中的檔案大小",
         "dlSpeedAverage": "平均下載速率",
-        "upSpeedAverage": "平均上傳速率",
-        "fileCount": "檔案數"
+        "upSpeedAverage": "平均上傳速率"
       },
       "pageInfo": {
         "eta": "預估剩餘時間",


### PR DESCRIPTION
# Use selected file count instead of total file count to preview filename [perf]

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
