### PR TITLE
perf(overview): Disable canvas generation on large torrents

### DIFF
--- a/src/components/Settings/Tabs/VueTorrent/VGeneral.vue
+++ b/src/components/Settings/Tabs/VueTorrent/VGeneral.vue
@@ -40,18 +40,31 @@
       <v-checkbox v-model="settings.openSideBarOnStart" hide-details class="ma-0 pa-0" :label="$t('modals.settings.vueTorrent.general.openSideBarOnStart')" />
     </v-list-item>
 
-    <v-list-item class="mb-3">
+    <v-list-item>
       <v-checkbox v-model="settings.showShutdownButton" hide-details class="ma-0 pa-0" :label="$t('modals.settings.vueTorrent.general.showShutdownButton')" />
     </v-list-item>
 
-    <v-list-item class="mb-3">
-      <v-text-field
-          v-model="settings.refreshInterval"
-          type="number"
-          dense
-          outlined
-          :hint="$t('modals.settings.vueTorrent.general.refreshIntervalHint')"
-          :label="$t('modals.settings.vueTorrent.general.refreshInterval')" />
+    <v-list-item class="my-2">
+      <v-row>
+        <v-col cols="12" sm="6" class="mb-n4">
+          <v-text-field
+              v-model="settings.refreshInterval"
+              type="number"
+              dense
+              outlined
+              :hint="$t('modals.settings.vueTorrent.general.refreshIntervalHint')"
+              :label="$t('modals.settings.vueTorrent.general.refreshInterval')" />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-text-field
+              v-model="settings.torrentPieceCountRenderThreshold"
+              type="number"
+              dense
+              outlined
+              :hint="$t('modals.settings.vueTorrent.general.torrentPieceCountRenderThresholdHint')"
+              :label="$t('modals.settings.vueTorrent.general.torrentPieceCountRenderThreshold')" />
+        </v-col>
+      </v-row>
     </v-list-item>
 
     <v-list-item class="mb-3">
@@ -140,14 +153,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
-import { mapState, mapGetters } from 'vuex'
-import { Qbit } from '@/services/qbit'
-import { LOCALES } from '@/lang/locales'
-import { General } from '@/mixins'
-import { TitleOptions } from '@/enums/vuetorrent'
+import {defineComponent} from 'vue'
+import {mapGetters, mapState} from 'vuex'
+import {Qbit} from '@/services/qbit'
+import {LOCALES} from '@/lang/locales'
+import {General} from '@/mixins'
+import {TitleOptions} from '@/enums/vuetorrent'
 import Ajv from 'ajv'
-import { StoreStateSchema } from '@/schemas'
+import {StoreStateSchema} from '@/schemas'
 import WebUISettings from '@/types/vuetorrent/WebUISettings'
 
 export default defineComponent({

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -73,6 +73,12 @@ export function getDataValue(data: number, precision: number = 2) {
 
 Vue.filter('getDataValue', getDataValue)
 
+export function getData(data: number, precision: number = 2) {
+  return `${getDataValue(data, precision)} ${getDataUnit(data)}`
+}
+
+Vue.filter('getData', getData)
+
 export function titleCase(str: string): string {
   if (str.length == 0) return str
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -656,6 +656,8 @@
       "tabTitleTagsCategories": "Tags & Categories",
       "pageOverview": {
         "fetchingMetadata": "Fetching...",
+        "waitingForMetadata": "Waiting for metadata...",
+        "disabledCanvas": "Canvas disabled to save performance",
         "selectedFileSize": "Selected Files' Size",
         "dlSpeedAverage": "Download Speed Average",
         "upSpeedAverage": "Upload Speed Average",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -271,6 +271,8 @@
           "showShutdownButton": "Show shutdown button",
           "refreshInterval": "qBittorrent API refresh interval",
           "refreshIntervalHint": "In milliseconds",
+          "torrentPieceCountRenderThreshold": "Torrent piece count to disable rendering",
+          "torrentPieceCountRenderThresholdHint": "In milliseconds",
           "currentVersion": "Current Version",
           "qbittorrentVersion": "QBittorrent Version",
           "registerMagnet": "Register magnet links",

--- a/src/schemas/StoreState.ts
+++ b/src/schemas/StoreState.ts
@@ -1,6 +1,6 @@
-import { JSONSchemaType } from 'ajv'
-import { PersistentStoreState } from '@/types/vuetorrent'
-import { DashboardProperty, TitleOptions } from '@/enums/vuetorrent'
+import {JSONSchemaType} from 'ajv'
+import {PersistentStoreState} from '@/types/vuetorrent'
+import {DashboardProperty, TitleOptions} from '@/enums/vuetorrent'
 
 export const StoreStateSchema: JSONSchemaType<PersistentStoreState> = {
   type: 'object',
@@ -43,6 +43,7 @@ export const StoreStateSchema: JSONSchemaType<PersistentStoreState> = {
         openSideBarOnStart: { type: 'boolean' },
         showShutdownButton: { type: 'boolean' },
         refreshInterval: { type: 'number' },
+        torrentPieceCountRenderThreshold: { type: 'number' },
         busyDesktopTorrentProperties: { $ref: '/schemas/desktopDashboardProperties' },
         doneDesktopTorrentProperties: { $ref: '/schemas/desktopDashboardProperties' },
         busyMobileCardProperties: { $ref: '/schemas/mobileDashboardProperties' },
@@ -67,6 +68,7 @@ export const StoreStateSchema: JSONSchemaType<PersistentStoreState> = {
         'openSideBarOnStart',
         'showShutdownButton',
         'refreshInterval',
+        'torrentPieceCountRenderThreshold',
         'busyDesktopTorrentProperties',
         'doneDesktopTorrentProperties',
         'busyMobileCardProperties',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,10 +4,10 @@ import VuexPersist from 'vuex-persist'
 import actions from './actions'
 import getters from './getters'
 import mutations from './mutations'
-import type { StoreState, PersistentStoreState } from '@/types/vuetorrent'
-import { Status } from '@/models'
-import { TitleOptions, DashboardProperty } from '@/enums/vuetorrent'
-import { AppPreferences } from '@/types/qbit/models'
+import type {PersistentStoreState, StoreState} from '@/types/vuetorrent'
+import {Status} from '@/models'
+import {DashboardProperty, TitleOptions} from '@/enums/vuetorrent'
+import {AppPreferences} from '@/types/qbit/models'
 
 const vuexPersist = new VuexPersist<PersistentStoreState>({
   key: 'vuetorrent',
@@ -136,13 +136,14 @@ export default new Vuex.Store<StoreState>({
       openSideBarOnStart: true,
       showShutdownButton: true,
       refreshInterval: 2000,
+      torrentPieceCountRenderThreshold: 5000,
       busyDesktopTorrentProperties: JSON.parse(JSON.stringify(desktopPropertiesTemplate)),
       doneDesktopTorrentProperties: JSON.parse(JSON.stringify(desktopPropertiesTemplate)),
       busyMobileCardProperties: JSON.parse(JSON.stringify(mobilePropertiesTemplate)),
       doneMobileCardProperties: JSON.parse(JSON.stringify(mobilePropertiesTemplate))
     }
   },
-  // @ts-expect-error
+  //@ts-expect-error: TS2322: Type '...' is not assignable to type 'ActionTree<StoreState, StoreState>'.
   actions: {
     ...actions
   },

--- a/src/types/vuetorrent/WebUISettings.ts
+++ b/src/types/vuetorrent/WebUISettings.ts
@@ -1,4 +1,4 @@
-import type { DashboardProperty, TitleOptions } from '@/enums/vuetorrent'
+import type {DashboardProperty, TitleOptions} from '@/enums/vuetorrent'
 
 export class TorrentProperty {
   name: DashboardProperty
@@ -29,6 +29,7 @@ export default interface WebUISettings {
   openSideBarOnStart: boolean
   showShutdownButton: boolean
   refreshInterval: number
+  torrentPieceCountRenderThreshold: number
   busyDesktopTorrentProperties: TorrentProperty[]
   doneDesktopTorrentProperties: TorrentProperty[]
   busyMobileCardProperties: TorrentProperty[]

--- a/tests/unit/__snapshots__/General.spec.ts.snap
+++ b/tests/unit/__snapshots__/General.spec.ts.snap
@@ -30,11 +30,18 @@ exports[`General > render correctly 1`] = `
   <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\">
     <v-checkbox-stub data-v-7da6d3e2=\\"\\" errorcount=\\"1\\" errormessages=\\"\\" messages=\\"\\" rules=\\"\\" successmessages=\\"\\" backgroundcolor=\\"\\" hidedetails=\\"true\\" ripple=\\"true\\" valuecomparator=\\"[Function]\\" indeterminateicon=\\"$checkboxIndeterminate\\" officon=\\"$checkboxOff\\" onicon=\\"$checkboxOn\\" class=\\"ma-0 pa-0\\"></v-checkbox-stub>
   </v-list-item-stub>
-  <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\" class=\\"mb-3\\">
+  <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\">
     <v-checkbox-stub data-v-7da6d3e2=\\"\\" errorcount=\\"1\\" errormessages=\\"\\" messages=\\"\\" rules=\\"\\" successmessages=\\"\\" backgroundcolor=\\"\\" hidedetails=\\"true\\" ripple=\\"true\\" valuecomparator=\\"[Function]\\" indeterminateicon=\\"$checkboxIndeterminate\\" officon=\\"$checkboxOff\\" onicon=\\"$checkboxOn\\" class=\\"ma-0 pa-0\\"></v-checkbox-stub>
   </v-list-item-stub>
-  <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\" class=\\"mb-3\\">
-    <v-text-field-stub data-v-7da6d3e2=\\"\\" errorcount=\\"1\\" errormessages=\\"\\" messages=\\"\\" rules=\\"\\" successmessages=\\"\\" backgroundcolor=\\"\\" dense=\\"true\\" loaderheight=\\"2\\" clearicon=\\"$clear\\" outlined=\\"true\\" type=\\"number\\"></v-text-field-stub>
+  <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\" class=\\"my-2\\">
+    <v-row-stub data-v-7da6d3e2=\\"\\" tag=\\"div\\">
+      <v-col-stub data-v-7da6d3e2=\\"\\" cols=\\"12\\" sm=\\"6\\" tag=\\"div\\" class=\\"mb-n4\\">
+        <v-text-field-stub data-v-7da6d3e2=\\"\\" errorcount=\\"1\\" errormessages=\\"\\" messages=\\"\\" rules=\\"\\" successmessages=\\"\\" backgroundcolor=\\"\\" dense=\\"true\\" loaderheight=\\"2\\" clearicon=\\"$clear\\" outlined=\\"true\\" type=\\"number\\"></v-text-field-stub>
+      </v-col-stub>
+      <v-col-stub data-v-7da6d3e2=\\"\\" cols=\\"12\\" sm=\\"6\\" tag=\\"div\\">
+        <v-text-field-stub data-v-7da6d3e2=\\"\\" errorcount=\\"1\\" errormessages=\\"\\" messages=\\"\\" rules=\\"\\" successmessages=\\"\\" backgroundcolor=\\"\\" dense=\\"true\\" loaderheight=\\"2\\" clearicon=\\"$clear\\" outlined=\\"true\\" type=\\"number\\"></v-text-field-stub>
+      </v-col-stub>
+    </v-row-stub>
   </v-list-item-stub>
   <v-list-item-stub data-v-7da6d3e2=\\"\\" activeclass=\\"\\" tag=\\"div\\" class=\\"mb-3\\">
     <v-row-stub data-v-7da6d3e2=\\"\\" tag=\\"div\\">


### PR DESCRIPTION
# Disable canvas generation on large torrents [perf]

- Improve layout
- Disable canvas reload with a lot of pieces
- Add store settings to configure large torrent threshold

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
