### PR TITLE
chore: Revert sass bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eslint-plugin-vue": "^9",
         "jsdom": "^22.1.0",
         "prettier": "^3",
-        "sass": "~1.63.6",
+        "sass": "~1.32.13",
         "unplugin-vue-components": "^0.25",
         "vite": "^4",
         "vite-plugin-eslint": "^1",
@@ -4927,12 +4927,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6449,20 +6443,18 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.63.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
-      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
+        "chokidar": ">=3.0.0 <4.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=8.9.0"
       }
     },
     "node_modules/saxes": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-vue": "^9",
     "jsdom": "^22.1.0",
     "prettier": "^3",
-    "sass": "~1.63.6",
+    "sass": "~1.32.13",
     "unplugin-vue-components": "^0.25",
     "vite": "^4",
     "vite-plugin-eslint": "^1",


### PR DESCRIPTION
# Revert sass bump [chore]

Revert SASS bump from dependabot (#885) to remove deprecation warnings.
Deprecation has been fixed with Vuetify 3. Update to Vue 3 will fix it as well.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
