### PR TITLE
perf(torrentDetail): top actions fire on currently focused torrent

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ export default {
         this.$store.commit('LOGIN', true)
         this.$store.commit('updateMainData')
         await this.$store.dispatch('FETCH_SETTINGS')
-        if (this.onLoginPage) return this.$router.push('/')
+        if (this.onLoginPage) return this.$router.push('dashboard')
 
         return
       }

--- a/src/components/Modals/ConfirmDeleteModal.vue
+++ b/src/components/Modals/ConfirmDeleteModal.vue
@@ -68,6 +68,10 @@ export default defineComponent({
       await qbit.deleteTorrents(this.selection, this.settings.deleteWithFiles)
       this.$store.commit('RESET_SELECTED')
       this.close()
+
+      if (this.$route.name === 'torrentDetail') {
+        this.$router.push({ name: 'dashboard' })
+      }
     }
   }
 })

--- a/src/components/Navbar/TopActions.vue
+++ b/src/components/Navbar/TopActions.vue
@@ -83,9 +83,10 @@
   </div>
 </template>
 
-<script>
-import { General } from '@/mixins'
+<script lang="ts">
+import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
+import { General } from '@/mixins'
 import qbit from '@/services/qbit'
 import {
   mdiSort,
@@ -102,7 +103,7 @@ import {
   mdiPower
 } from '@mdi/js'
 
-export default {
+export default defineComponent({
   name: 'TopActions',
   mixins: [General],
   props: {
@@ -126,19 +127,27 @@ export default {
     }
   },
   computed: {
-    ...mapState(['selected_torrents'])
+    ...mapState(['selected_torrents']),
+    isOnTorrentDetail() {
+      return this.$route.name === 'torrentDetail'
+    },
+    hashes(): string[] {
+      return (this.isOnTorrentDetail)
+          ? [this.$route.params.hash]
+          : this.selected_torrents
+    }
   },
   methods: {
     async pauseTorrents() {
-      await qbit.pauseTorrents(this.selected_torrents)
+      await qbit.pauseTorrents(this.hashes)
     },
     async resumeTorrents() {
-      await qbit.resumeTorrents(this.selected_torrents)
+      await qbit.resumeTorrents(this.hashes)
     },
     removeTorrents() {
-      if (!this.selected_torrents.length) return
+      if (!this.hashes.length) return
 
-      return this.createModal('ConfirmDeleteModal', { hashes: this.selected_torrents })
+      return this.createModal('ConfirmDeleteModal', { hashes: this.hashes })
     },
     goToSearch() {
       if (this.$route.name !== 'search') this.$router.push({ name: 'search' })
@@ -153,5 +162,5 @@ export default {
       if (this.$route.name !== 'settings') this.$router.push({ name: 'settings' })
     }
   }
-}
+})
 </script>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -61,7 +61,7 @@ export default {
   },
   mounted() {
     if (isAuthenticated()) {
-      this.$router.push('/')
+      this.$router.push('dashboard')
     }
   },
   methods: {
@@ -72,7 +72,7 @@ export default {
       })
 
       if (authenticated) {
-        this.$router.push('/')
+        this.$router.push('dashboard')
       }
     }
   }

--- a/src/views/MagnetHandler.vue
+++ b/src/views/MagnetHandler.vue
@@ -10,7 +10,7 @@ export default {
   props: ['magnet'],
   created() {
     this.createModal('AddModal', { initialMagnet: this.magnet })
-    this.$router.push('/')
+    this.$router.push('dashboard')
   }
 }
 </script>


### PR DESCRIPTION
# Top Actions fire on currently focused torrent [perf]

When on a TorrentDetail page, top actions will fire calls on currently focused torrent instead of selection / all.
*Added a redirect to dashboard when deleting torrent in that condition to prevent client errors.*

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
