### PR TITLE
fix: App not redirecting to login page on load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,8 +54,8 @@ export default {
         return
       }
 
-      // this.$store.commit('LOGIN', false)
-      // if (!this.onLoginPage) return this.$router.push({ name: 'login', query: { redirect: this.$route.fullPath } })
+      this.$store.commit('LOGIN', false)
+      if (!this.onLoginPage) return this.$router.push({ name: 'login', query: { redirect: this.$route.fullPath } })
     },
     blockContextMenu() {
       document.addEventListener('contextmenu', event => {


### PR DESCRIPTION
# App not redirecting to login page [fix]

When old session is expired, state is still authenticated so no redirect was made when the app was reloaded.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
