### PR TITLE
perf(overview): Disable canvas first-time render

### DIFF
--- a/src/components/TorrentDetail/Tabs/Overview.vue
+++ b/src/components/TorrentDetail/Tabs/Overview.vue
@@ -31,7 +31,7 @@
                     {{ $t('modals.detail.pageOverview.waitingForMetadata') }}
                   </span>
                 </div>
-                <div v-else>
+                <div v-else-if="!shouldRenderPieceStates">
                   <canvas id="pieceStates" width="0" height="1" />
                 </div>
                 <div v-if="!isFetchingMetadata && !shouldRenderPieceStates">

--- a/src/components/TorrentDetail/Tabs/Overview.vue
+++ b/src/components/TorrentDetail/Tabs/Overview.vue
@@ -182,7 +182,7 @@ export default defineComponent({
   async mounted() {
     await this.getTorrentProperties()
     await this.updateSelectedFiles()
-    if (!this.shouldRenderPieceStates) {
+    if (this.shouldRenderPieceStates) {
       await this.renderTorrentPieceStates()
     }
   },

--- a/src/components/TorrentDetail/Tabs/Overview.vue
+++ b/src/components/TorrentDetail/Tabs/Overview.vue
@@ -182,7 +182,9 @@ export default defineComponent({
   async mounted() {
     await this.getTorrentProperties()
     await this.updateSelectedFiles()
-    await this.renderTorrentPieceStates()
+    if (!this.shouldRenderPieceStates) {
+      await this.renderTorrentPieceStates()
+    }
   },
   computed: {
     ...mapState(['webuiSettings']),


### PR DESCRIPTION
# Disable canvas first-time render [perf]

Disable canvas first-time render to prevent freezes when opening Torrent Detail
Fixes #1023 

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
