### PR TITLE
fixing progress and relevance numbers in DetiledPeers screen

### DIFF
--- a/src/components/TorrentDetail/Tabs/DetailPeers.vue
+++ b/src/components/TorrentDetail/Tabs/DetailPeers.vue
@@ -23,12 +23,12 @@
                 {{ item.flags }}
               </td>
               <td>{{ item.client }}</td>
-              <td>{{ item.progress | progress }}</td>
+              <td>{{ (item.progress * 100) | progress }}</td>
               <td>{{ item.dl_speed | formatSpeed(shouldUseBitSpeed()) }}</td>
               <td>{{ item.downloaded | formatData(shouldUseBinaryData()) }}</td>
               <td>{{ item.up_speed | formatSpeed(shouldUseBitSpeed()) }}</td>
               <td>{{ item.uploaded | formatData(shouldUseBinaryData()) }}</td>
-              <td>{{ item.relevance | progress }}</td>
+              <td>{{ (item.relevance * 100) | progress }}</td>
               <td>{{ item.files }}</td>
             </tr>
           </tbody>


### PR DESCRIPTION
# fixing progress and relavance numbers in DetiledPeers screen [fix]

In peer details screen we are seeing progress and relevance are shown with % associated to them.but the value returned over here is in terms of ratio. fixing this by multiplying value given by peer details call by 100.

closes https://github.com/WDaan/VueTorrent/issues/1033

after:

![Screenshot 2023-08-09 at 19 51 50](https://github.com/WDaan/VueTorrent/assets/106881717/386ad40d-ae8a-45f3-9e1b-5b73e5626ef2)


# PR Checklist

- [*] I've started from master
- [*] I've only committed changes related to this PR
- [*] All Unit tests pass
- [*] I've removed all commented code
- [*] I've removed all unneeded console.log statements
