### PR TITLE
adding darker colour to files actively or force uploading

### DIFF
--- a/src/enums/vuetorrent/TorrentState.ts
+++ b/src/enums/vuetorrent/TorrentState.ts
@@ -1,6 +1,7 @@
 export enum TorrentState {
   DOWNLOADING = 'Downloading',
   SEEDING = 'Seeding',
+  UPLOADING = 'Uploading',
   PAUSED = 'Paused',
   STALLED = 'Stalled',
   METADATA = 'Metadata',

--- a/src/models/Torrent.ts
+++ b/src/models/Torrent.ts
@@ -126,6 +126,7 @@ export default class Torrent {
         return VtTorrentState.METADATA
       case QbitTorrentState.FORCED_UP:
       case QbitTorrentState.UPLOADING:
+        return VtTorrentState.UPLOADING
       case QbitTorrentState.STALLED_UP:
         return VtTorrentState.SEEDING
       case QbitTorrentState.PAUSED_DL:

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -31,6 +31,7 @@ const variables = {
   'torrent-errored': '#f83e70',
   'torrent-paused': '#9CA3AF',
   'torrent-queued': '#2e5eaa',
+  'torrent-uploading': '#4e79e6',
   'torrent-seeding': '#4ecde6',
   'torrent-checking': '#ff7043',
   'torrent-stalled': '#4ADE80',

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -15,6 +15,7 @@ $torrent-fail: #f83e70;
 $torrent-errored: $torrent-fail;
 $torrent-paused: #9ca3af;
 $torrent-queued: #2e5eaa;
+$torrent-uploading: #4e79e6;
 $torrent-seeding: #4ecde6;
 $torrent-checking: #ff7043;
 $torrent-stalled: #4ade80;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -21,6 +21,9 @@ $sideborder-margin: 6px;
 .sideborder.seeding {
   border-left: #{$sideborder-margin} solid #{$torrent-seeding};
 }
+.sideborder.uploading {
+  border-left: #{$sideborder-margin} solid #{$torrent-uploading};
+}
 .sideborder.checking {
   border-left: #{$sideborder-margin} solid #{$torrent-checking};
 }
@@ -53,6 +56,9 @@ $sideborder-margin: 6px;
 }
 .v-chip.seeding {
   background: #{$torrent-seeding} !important;
+}
+.v-chip.uploading {
+  background: #{$torrent-uploading} !important;
 }
 .v-chip.checking {
   background: #{$torrent-checking} !important;


### PR DESCRIPTION
# adding darker colour to files actively or force uploading [feat]
A file is actively getting uploaded (seeding with upload speed) and a file which is being seeded but no uploading speed are both show with state as seeding and same colour.

To distinguish between these two files:
1. applying `Uploading` state to the torrent file
2. applying darker shade of blue to sideboarder to actively uploading files

PS: files force uploading will also be considered as uploading.

<img width="720" alt="Screenshot 2023-08-10 at 03 24 33" src="https://github.com/WDaan/VueTorrent/assets/106881717/7d937f97-0a0a-459e-916b-5409e5d60757">

<img width="720" alt="Screenshot 2023-08-10 at 03 23 04" src="https://github.com/WDaan/VueTorrent/assets/106881717/cf334b0f-6555-4d4e-9ad3-5d55940e402a">

<img width="720" alt="Screenshot 2023-08-10 at 03 22 33" src="https://github.com/WDaan/VueTorrent/assets/106881717/2c9f7c96-712b-4110-a671-5c58d936e84b">


# PR Checklist

- [*] I've started from master
- [*] I've only committed changes related to this PR
- [*] All Unit tests pass
- [*] I've removed all commented code
- [*] I've removed all unneeded console.log statements
