### PR TITLE
fix(torrent): Wrong date format on longer duration than month

### DIFF
--- a/src/models/Torrent.ts
+++ b/src/models/Torrent.ts
@@ -9,7 +9,7 @@ import i18n from '@/plugins/i18n'
 dayjs.extend(duration)
 dayjs.extend(relativeTime)
 
-const durationFormat = 'D[d] H[h] m[m] s[s]'
+const durationFormat = 'H[h] m[m] s[s]'
 
 export default class Torrent {
   static computedValues = ['globalSpeed', 'globalVolume', 'priority']
@@ -63,6 +63,10 @@ export default class Torrent {
   globalSpeed: number
   globalVolume: number
   constructor(data: QbitTorrent, format = 'DD/MM/YYYY, HH:mm:ss') {
+    
+    const seeding_time_duration = data.seeding_time > 0 ? dayjs.duration(data.seeding_time, 'seconds') : null
+    const time_active_duration = dayjs.duration(data.time_active, 'seconds')
+    
     this.added_on = dayjs(data.added_on * 1000).format(format)
     this.amount_left = data.amount_left
     this.auto_tmm = data.auto_tmm
@@ -94,14 +98,14 @@ export default class Torrent {
     this.ratio_limit = data.max_ratio
     this.ratio_time_limit = data.max_seeding_time
     this.savePath = data.save_path
-    this.seeding_time = data.seeding_time > 0 ? dayjs.duration(data.seeding_time, 'seconds').format(durationFormat) : null
+    this.seeding_time = data.seeding_time > 0 ? (Math.floor(seeding_time_duration.asDays()) + 'd ' + seeding_time_duration.format(durationFormat)) : null
     this.seen_complete = data.seen_complete > 0 ? dayjs(data.seen_complete * 1000).format(format) : i18n.t('dashboard.not_complete').toString()
     this.seq_dl = data.seq_dl
     this.size = data.size
     this.state = this.formatState(data.state)
     this.super_seeding = data.super_seeding
     this.tags = data.tags.length > 0 ? data.tags.split(', ').map(t => t.trim()) : []
-    this.time_active = dayjs.duration(data.time_active, 'seconds').format(durationFormat)
+    this.time_active = Math.floor(time_active_duration.asDays()) + 'd ' + time_active_duration.format(durationFormat)
     this.total_size = data.total_size
     this.tracker = data.tracker
     this.trackers_count = data.trackers_count


### PR DESCRIPTION
# wrong date format on longer duration than month [fix]

Time Active row in Info tab has wrong format on longer duration than month. This is know issue with dayjs library.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
