### PR TITLE
fix: app js file cached in PWA mode

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -61,6 +61,7 @@ export default defineConfig(({ mode }) => {
         base: './',
         useCredentials: true,
         workbox: {
+          maximumFileSizeToCacheInBytes: 10000000,
           skipWaiting: true,
           globPatterns: ['**/*.{js,css,html,ico,png,svg}']
         }


### PR DESCRIPTION
# app js file cached in PWA mode [fix]

In PWA mode, largest .js file was downloaded every time the app opens.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
