### PR TITLE
fix: cache fonts in PWA mode

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -62,7 +62,7 @@ export default defineConfig(({ mode }) => {
         useCredentials: true,
         workbox: {
           skipWaiting: true,
-          globPatterns: ['**/*.{js,css,html,ico,png,svg}']
+          globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}']
         }
       })
     ],


### PR DESCRIPTION
# cache fonts in PWA mode [fix]

Font files with extensions woff and woff2 are now properly cached when app is istalled as PWA

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
