### PR TITLE
fix(styles): overflowing tab arrows with light theme

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -190,3 +190,13 @@ body {
 .v-data-table {
   width: 100% !important;
 }
+
+.v-tabs--align-with-title.theme--light>.v-slide-group--is-overflowing>.v-slide-group__prev>.v-icon,
+.v-tabs--align-with-title.theme--light>.v-slide-group--is-overflowing>.v-slide-group__next>.v-icon {
+    color: white;
+}
+
+.v-tabs--align-with-title.theme--light>.v-slide-group--is-overflowing>.v-slide-group__prev--disabled>.v-icon,
+.v-tabs--align-with-title.theme--light>.v-slide-group--is-overflowing>.v-slide-group__next--disabled>.v-icon {
+    color: #ffffffB0 !important;
+}


### PR DESCRIPTION
# dark overflowing tab arrows with light theme [fix]

On mobile, tab arrows with light theme remains nearly invisible dark color. PR fixes arrows to style them with light color.

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
