### PR TITLE
fixing magnet handling

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -41,8 +41,7 @@ const router = new Router({
     {
       path: '/download=:magnet',
       name: 'MagnetHandler',
-      component: () => import('./views/MagnetHandler.vue'),
-      props: true
+      component: () => import('./views/MagnetHandler.vue')
     },
     {
       path: '/login',

--- a/src/views/MagnetHandler.vue
+++ b/src/views/MagnetHandler.vue
@@ -7,9 +7,9 @@ import { General } from '@/mixins'
 export default {
   name: 'MagnetHandler',
   mixins: [General],
-  props: ['magnet'],
   created() {
-    this.createModal('AddModal', { initialMagnet: this.magnet })
+    const regex = new RegExp('^\/download\=(.+?)(?:\/(?=$))?$', 'is')
+    this.createModal('AddModal', { initialMagnet: regex.exec(this.$route.fullPath)[1] })
     this.$router.push({ name: 'dashboard' })
   }
 }


### PR DESCRIPTION
# magnet handling [fix]

when vuetorrent is used for magnet handling its not capturing whole magnet link rather it only captures till magnet:

Fixed this by using custom regex just for /download route.

Tested with single line and multiline magnet torrent links. Future testing is appreciated.

POT: 


https://github.com/WDaan/VueTorrent/assets/106881717/f48fde60-a7f2-423d-8a9c-0518880d5302


# PR Checklist

- [*] I've started from master
- [*] I've only committed changes related to this PR
- [*] All Unit tests pass
- [*] I've removed all commented code
- [*] I've removed all unneeded console.log statements
