### PR TITLE
fixing magnet handling issue caused by #1041

### DIFF
--- a/src/views/MagnetHandler.vue
+++ b/src/views/MagnetHandler.vue
@@ -7,9 +7,19 @@ import { General } from '@/mixins'
 export default {
   name: 'MagnetHandler',
   mixins: [General],
+  methods: {
+    decodeMagnet(url) {
+      if (url.startsWith('magnet:?')) {
+        return url
+      } else {
+        return this.decodeMagnet(decodeURIComponent(url))
+      }
+    }
+  },
   created() {
     const regex = new RegExp('^\/download\=(.+?)(?:\/(?=$))?$', 'is')
-    this.createModal('AddModal', { initialMagnet: regex.exec(this.$route.fullPath)[1] })
+    let magnetLink = this.decodeMagnet(regex.exec(this.$route.fullPath)[1])
+    this.createModal('AddModal', { initialMagnet: magnetLink })
     this.$router.push({ name: 'dashboard' })
   }
 }


### PR DESCRIPTION
# fixing magnet handling issue caused by #1041 [fix]

In my Previous PR #1041 I have fixed magentHandling when unEncoded Magnet URL is used for magnetHandling. But this caused a issue with auto-grabing of Magnet links as these as Encoded from the Browser side. 
Fixing the issue introduced in above PR here.

Closes https://github.com/WDaan/VueTorrent/issues/1054 

# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
