### PR TITLE
[fix]explicitly match the filename

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -47,7 +47,7 @@ export function genFileTree(files) {
       .reduce((parentPath, nodeName) => {
         const nextPath = parentPath === '' ? nodeName : parentPath + '/' + nodeName
 
-        if (file.name.endsWith(nodeName)) {
+        if (file.name.replace('\\', '/').split('/').pop() === nodeName) {
           /** @type {TreeFile} */
           const newFile = {
             type: 'file',


### PR DESCRIPTION
# [fix]explicitly match the filename

This PR resolves an edge case where if a file extension contains the name of the parent folder, it fails to add that file to the content tree. Resolves #1052

# PR Checklist

- [x ] I've started from master
- [x ] I've only committed changes related to this PR
- [x ] All Unit tests pass
- [x ] I've removed all commented code
- [x ] I've removed all unneeded console.log statements
