### PR TITLE
fixing formatDataValues for values with 4 digits or more fixes #1079

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -24,7 +24,9 @@ export function formatDataValue(data: number, isBinary: boolean) {
   while (data >= base ** i) {
     i++
   }
-  return toPrecision(data / base ** (i - 1), i > 1 ? 3 : 1)
+  let value = data / base ** (i - 1)
+  if (value > 999) return toPrecision(value,4)
+  return toPrecision(value, i > 1 ? 3 : 1)
 }
 Vue.filter('formatDataValue', formatDataValue)
 


### PR DESCRIPTION
# fixing formatDaataValues for values with 4 digits or more fixes [fix]

in formatDataValues function we are using toPrecision funtion with precision value as 3 which when round off value reaches 4 digits returns exponential values. Fixed this by using checking if he value is above 999 and giving precision value 4 if the same is true.

Gave value :  
<img width="144" alt="Screenshot 2023-09-04 at 06 28 37" src="https://github.com/WDaan/VueTorrent/assets/106881717/4be2918a-c499-4839-ad91-590b00d65d9e">


function returned : 
<img width="42" alt="Screenshot 2023-09-04 at 06 28 43" src="https://github.com/WDaan/VueTorrent/assets/106881717/55b23665-c429-4b3c-b9ed-b1783835ad2c">


# PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All Unit tests pass
- [x] I've removed all commented code
- [x] I've removed all unneeded console.log statements
