### PR TITLE
feat!: Login with url query

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -60,7 +60,13 @@ export default {
       mdiAccount
     }
   },
-  mounted() {
+  async mounted() {
+    if (this.$route.query.username !== undefined && this.$route.query.password !== undefined) {
+      this.authenticated = await this.$store.dispatch('LOGIN',{
+        username: this.$route.query.username,
+        password: this.$route.query.password
+      })
+    }
     if (this.authenticated) {
       this.redirectOnSuccess()
     }


### PR DESCRIPTION
Login by passing url query parameter `username` and `password` to route `login`

# Rationale

With this feature, if you open `http://some_address:8080/#/login?username=username&password=password` in the browser, you can login directly to the dashboard.

I propose this feature because I'm embedding VueTorrent to an iframe on my net disk 's web-ui, and I hope to save the trouble of typing username and password all over again.

If there's anything inappropriate with this proposal, please point it out and I will understand.

Finally, I really like this beautiful and powerful frontend. Lots of thanks to all your hard work.

# PR Checklist

- [*] I've started from master
- [*] I've only committed changes related to this PR
- [*] I've removed all commented code
- [*] I've removed all unneeded console.log statements
