### PR TITLE
feat(dashboard): Add infinite scroll

### DIFF
--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -6,7 +6,17 @@ import { computed, onBeforeMount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue3-toastify'
 
-const paginationSizes = ref([5, 15, 30, 50])
+const { t } = useI18n()
+const appStore = useAppStore()
+const vueTorrentStore = useVueTorrentStore()
+
+const paginationSizes = ref([
+  { title: t('settings.vuetorrent.general.paginationSize.infinite_scroll'), value: -1 },
+  5,
+  15,
+  30,
+  50
+])
 const settingsField = ref('')
 
 const isProduction = computed(() => process.env.NODE_ENV === 'production')
@@ -26,10 +36,6 @@ const theme = computed({
     }
   }
 })
-
-const { t } = useI18n()
-const appStore = useAppStore()
-const vueTorrentStore = useVueTorrentStore()
 
 const themeOptions = [
   { title: t('constants.theme.auto'), value: 'auto' },
@@ -150,7 +156,7 @@ onBeforeMount(() => {
           <v-select v-model="vueTorrentStore.language" flat hide-details :items="LOCALES" :label="t('settings.vuetorrent.general.language')" />
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-select v-model="vueTorrentStore.paginationSize" flat hide-details :items="paginationSizes" :label="t('settings.vuetorrent.general.paginationSize')" />
+          <v-select v-model="vueTorrentStore.paginationSize" flat hide-details :items="paginationSizes" :label="t('settings.vuetorrent.general.paginationSize.label')" />
         </v-col>
         <v-col cols="12" sm="6" md="3">
           <v-select v-model="vueTorrentStore.title" flat hide-details :items="titleOptionsList" :label="t('settings.vuetorrent.general.vueTorrentTitle')" />

--- a/src/composables/ArrayPagination.ts
+++ b/src/composables/ArrayPagination.ts
@@ -13,7 +13,7 @@ export function useArrayPagination<T>(items: MaybeRefOrGetter<T[]>, pageSize: Ma
   } = useOffsetPagination({
     total: toValue(items).length,
     page,
-    pageSize
+    pageSize: () => toValue(pageSize) === -1 ? toValue(items).length : toValue(pageSize),
   })
 
   const paginatedResults = computed(() => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -565,7 +565,10 @@
         "isPaginationOnTop": "Top Pagination",
         "matchSystemTheme": "Use System Theme",
         "language": "Language",
-        "paginationSize": "Pagination size",
+        "paginationSize": {
+          "label": "Pagination Size",
+          "infinite_scroll": "Infinite scroll"
+        },
         "vueTorrentTitle": "VueTorrent title",
         "dateFormat": "Date Format",
         "openSideBarOnStart": "Open Side Bar on launch",

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -288,7 +288,7 @@ function endPress() {
     </div>
     <div v-else>
       <v-list id="torrentList" class="pa-0" color="transparent">
-        <v-list-item v-if="vuetorrentStore.isPaginationOnTop">
+        <v-list-item v-if="vuetorrentStore.isPaginationOnTop && !vuetorrentStore.isInfiniteScrollActive">
           <v-pagination v-model="currentPage" :length="pageCount" next-icon="mdi-menu-right" prev-icon="mdi-menu-left"
                         @input="scrollToTop" />
         </v-list-item>
@@ -309,7 +309,7 @@ function endPress() {
           </div>
         </v-list-item>
 
-        <v-list-item v-if="!vuetorrentStore.isPaginationOnTop">
+        <v-list-item v-if="!vuetorrentStore.isPaginationOnTop && !vuetorrentStore.isInfiniteScrollActive">
           <v-pagination v-model="currentPage" :length="pageCount" next-icon="mdi-menu-right" prev-icon="mdi-menu-left"
                         @input="scrollToTop" />
         </v-list-item>

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -42,6 +42,7 @@ export const useVueTorrentStore = defineStore(
     const doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
 
     const getCurrentThemeName = computed(() => (darkMode.value ? Theme.DARK : Theme.LIGHT))
+    const isInfiniteScrollActive = computed(() => paginationSize.value === -1)
 
     const busyTorrentProperties = computed<TorrentProperty[]>(() => {
       const formattedPpt: TorrentProperty[] = new Array(Object.keys(propsData).length)
@@ -187,6 +188,7 @@ export const useVueTorrentStore = defineStore(
       busyTorrentProperties,
       doneTorrentProperties,
       getCurrentThemeName,
+      isInfiniteScrollActive,
       setLanguage,
       updateTheme,
       updateSystemTheme,


### PR DESCRIPTION
Rework of #1151

After some experimentations, Vuetify's `v-infinite-scroll` component isn't suitable because we have a finite list of items.

I haven't tested on a significant amount of torrents (51 max), performance issues will probably occur on large collections.
