### PR TITLE
fix(dashboard): Fix partial right click on mobile

### DIFF
--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -314,7 +314,7 @@ function endPress() {
 
         <v-list-item v-for="torrent in paginatedTorrents" :id="`torrent-${torrent.hash}`"
                      :class="display.mobile ? 'mb-2' : 'mb-4'" class="pa-0" @contextmenu="onRightClick($event, torrent)"
-                     @touchcancel="endPress" @touchend="endPress" @touchstart="startPress"
+                     @touchcancel="endPress" @touchend="endPress" @touchmove="endPress" @touchstart="startPress"
                      @dblclick.prevent="goToInfo(torrent.hash)">
           <div class="d-flex align-center">
             <v-expand-x-transition>


### PR DESCRIPTION
When holding a torrent then moving the view, right click action was still triggered.