### PR TITLE
fix(rss): Update overflow rules to handle long name without spaces

### DIFF
--- a/src/pages/RssArticles.vue
+++ b/src/pages/RssArticles.vue
@@ -127,7 +127,7 @@ onUnmounted(() => {
             <v-list-item :class="{ 'rss-read': article.isRead }" @click="showDescription(article)" @contextmenu="markAsRead(article)">
               <div class="d-flex">
                 <div>
-                  <v-list-item-title class="text-wrap">{{ article.title }}</v-list-item-title>
+                  <v-list-item-title class="wrap-anywhere" style="white-space: unset">{{ article.title }}</v-list-item-title>
 
                   <v-list-item-subtitle class="d-block">
                     <div>{{ article.parsedDate.toLocaleString() }}</div>


### PR DESCRIPTION
When RSS articles had long names without any spaces, text wrap didn't occur with `v-list-item-title`'s style. Icons were shown outside screen in those cases.