### PR TITLE
chore(ci): Fix version not up-to-date in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,14 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       upload_url: ${{ steps.release.outputs.upload_url }}
+      release_ref: ${{ steps.release.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Run release please
-        uses: google-github-actions/release-please-action@v3.7
+        uses: google-github-actions/release-please-action@v3
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,27 +26,35 @@ jobs:
 
   upload-release:
     needs: setup-release
-    if: ${{ needs.setup-release.outputs.release_created }}
+    if: needs.setup-release.outputs.release_created
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup-release.outputs.release_ref }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+
       - name: Build Node.js cache
         uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
+
       - name: Install dependencies
         run: npm ci
+
       - name: Build VueTorrent
         run: npm run build
+
       - name: Zip VueTorrent
         run: zip -qq -r ./vuetorrent.zip ./vuetorrent
+
       - name: Upload VueTorrent release
         uses: actions/upload-release-asset@v1
         env:
@@ -54,13 +64,16 @@ jobs:
           asset_path: ./vuetorrent.zip
           asset_name: vuetorrent.zip
           asset_content_type: application/zip
+
   push-release:
     needs: setup-release
-    if: ${{ needs.setup-release.outputs.release_created }}
+    if: needs.setup-release.outputs.release_created
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup-release.outputs.release_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Not sure if it'll do the trick but the problem is that the checked out ref is the one before the release.

It can be an async problem between jobs (which the `needs` should fix) or a default value problem (fixed in this PR)

#1247 