### PR TITLE
fix(AddTorrentDialog): Prevent undefined values from being sent through API

### DIFF
--- a/src/components/Dialogs/AddTorrentDialog.vue
+++ b/src/components/Dialogs/AddTorrentDialog.vue
@@ -137,18 +137,16 @@ const inactiveSeedingTimeLimit = computed({
 function submit() {
   if (!isFormValid.value) return
 
-  const promise = torrentStore.addTorrents(form.value, files.value)
-  .then(() => {
-    addTorrentStore.resetForm()
-    close()
-  })
-
-  toast.promise(promise, {
+  toast.promise(torrentStore.addTorrents(files.value, urls.value, form.value), {
     pending: t('dialogs.add.pending'),
     error: t('dialogs.add.error', addTorrentStore.pendingTorrentsCount),
     success: t('dialogs.add.success', addTorrentStore.pendingTorrentsCount)
   }, {
     autoClose: 1500
+  })
+  .then(() => {
+    addTorrentStore.resetForm()
+    close()
   })
 }
 

--- a/src/services/qbit.ts
+++ b/src/services/qbit.ts
@@ -226,14 +226,14 @@ export class QBitApi {
 
   // Post
 
-  async addTorrents(params: AddTorrentPayload, torrents: File[]): Promise<void> {
+  async addTorrents(torrents: File[], urls: string, params: AddTorrentPayload): Promise<void> {
     let data
     if (torrents) {
       // torrent files
       const formData = new FormData()
       if (params) {
         for (const [key, value] of Object.entries(params)) {
-          formData.append(key, value)
+          !!value && formData.set(key, value)
         }
       }
 
@@ -246,7 +246,7 @@ export class QBitApi {
       // magnet links
       data = new URLSearchParams(params as Parameters)
     }
-
+    !!urls && data.set('urls', urls)
     return this.axios.post('/torrents/add', data)
   }
 

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -99,8 +99,8 @@ export const useTorrentStore = defineStore('torrents', () => {
     await qbit.setTorrentLocation(hashes, newPath)
   }
 
-  async function addTorrents(payload: AddTorrentPayload, torrents: File[]) {
-    return await qbit.addTorrents(payload, torrents)
+  async function addTorrents(torrents: File[], urls: string, payload: AddTorrentPayload) {
+    return await qbit.addTorrents(torrents, urls, payload)
   }
 
   async function getTorrentProperties(hash: string) {

--- a/src/types/qbit/payloads/AddTorrentPayload.ts
+++ b/src/types/qbit/payloads/AddTorrentPayload.ts
@@ -49,8 +49,6 @@ export default interface AddTorrentPayload {
   tags?: string
   /** Set torrent upload speed limit. Unit in bytes/second */
   upLimit?: number
-  /** URLs separated with newlines */
-  urls?: string
   /** Whether to enable use of `downloadPath` */
   useDownloadPath?: boolean
 }


### PR DESCRIPTION
Seems like `FormData::set` and `FormData::append` converts everything to string except files and blobs, including `null` and `undefined`.

Fixes #1326 