### PR TITLE
feat(RSS): Add conf to use ID instead of link

### DIFF
--- a/src/components/Settings/RSS/General.vue
+++ b/src/components/Settings/RSS/General.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 
-import { usePreferenceStore } from '@/stores'
+import { usePreferenceStore, useVueTorrentStore } from '@/stores'
 
 const preferenceStore = usePreferenceStore()
+const vuetorrentStore = useVueTorrentStore()
 </script>
 
 <template>
@@ -54,6 +55,14 @@ const preferenceStore = usePreferenceStore()
         persistent-hint
         :hint="$t('settings.rss.general.smartEpisodeFilter.filtersHint')"
         :label="$t('settings.rss.general.smartEpisodeFilter.filters')" />
+    </v-list-item>
+
+    <v-divider />
+
+    <v-list-item>
+      <v-checkbox v-model="vuetorrentStore.useIdForRssLinks"
+                  hide-details
+                  :label="$t('settings.rss.general.useIdForRssLinks')" />
     </v-list-item>
   </v-list>
 </template>

--- a/src/pages/RssArticles.vue
+++ b/src/pages/RssArticles.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useArrayPagination, useSearchQuery } from '@/composables'
-import { useAddTorrentStore, useDialogStore, useRssStore } from '@/stores'
+import { useAddTorrentStore, useDialogStore, useRssStore, useVueTorrentStore } from '@/stores'
 import { RssArticle } from '@/types/vuetorrent'
 import debounce from 'lodash.debounce'
 import { computed, onBeforeMount, onMounted, onUnmounted, reactive, ref } from 'vue'
@@ -12,6 +12,7 @@ const { t } = useI18n()
 const addTorrentStore = useAddTorrentStore()
 const dialogStore = useDialogStore()
 const rssStore = useRssStore()
+const vuetorrentStore = useVueTorrentStore()
 
 const descriptionDialogVisible = ref(false)
 const rssDescription = reactive({
@@ -34,14 +35,15 @@ const searchQuery = useSearchQuery(
 
 const { paginatedResults, currentPage, pageCount } = useArrayPagination(searchQuery.results, 15)
 
-function openLink(url: string) {
+function openLink(article: RssArticle) {
+  const url = vuetorrentStore.useIdForRssLinks ? article.id : article.link
   window.open(url, '_blank', 'noreferrer')
 }
 
 function showDescription(article: RssArticle) {
   if (!article.description) return
-  rssDescription.title = article.title
-  rssDescription.content = article.description
+  rssDescription.title = article.title.trim()
+  rssDescription.content = article.description.trim()
   descriptionDialogVisible.value = true
 }
 
@@ -148,7 +150,7 @@ onUnmounted(() => {
                 <v-spacer />
 
                 <div class="d-flex flex-column">
-                  <v-btn icon="mdi-open-in-new" variant="text" @click.stop="openLink(article.link)" />
+                  <v-btn icon="mdi-open-in-new" variant="text" @click.stop="openLink(article)" />
                   <v-btn color="accent" icon="mdi-check" variant="text" @click.stop="markAsRead(article)" />
                   <v-btn icon="mdi-download" variant="text" @click.stop="downloadArticle(article)" />
                 </div>

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -42,6 +42,7 @@ export const useVueTorrentStore = defineStore(
     const fileContentInterval = ref(5000)
     const canvasRenderThreshold = ref(3000)
     const canvasRefreshThreshold = ref(5000)
+    const useIdForRssLinks = ref(false)
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
     const _doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -162,6 +163,7 @@ export const useVueTorrentStore = defineStore(
       uiTitleCustom,
       useBinarySize,
       useBitSpeed,
+      useIdForRssLinks,
       _busyProperties,
       busyTorrentProperties,
       _doneProperties,

--- a/src/types/qbit/models/FeedArticle.ts
+++ b/src/types/qbit/models/FeedArticle.ts
@@ -1,11 +1,20 @@
 export default interface FeedArticle {
+  /** Article author */
   author: string
+  /** Article category */
   category: string
+  /** Article publication date */
   date: string
+  /** Article description */
   description: string
+  /** Article ID */
   id: string
+  /** Whether the article has already been read */
   isRead: boolean
+  /** Article link */
   link: string
+  /** Article title */
   title: string
+  /** Torrent download URL */
   torrentURL: string
 }

--- a/src/types/vuetorrent/RssArticle.ts
+++ b/src/types/vuetorrent/RssArticle.ts
@@ -1,5 +1,6 @@
 import { FeedArticle } from '@/types/qbit/models'
 
 export interface RssArticle extends FeedArticle {
+  /** Article publication date parsed by dayjs */
   parsedDate: Date
 }


### PR DESCRIPTION
Added a checkbox in the Settings/RSS page to use the `id` attribute instead of the `link` attribute.

Fixes #1270 