### PR TITLE
perf: Prevent rounding for relative time values

### DIFF
--- a/src/plugins/dayjs.ts
+++ b/src/plugins/dayjs.ts
@@ -2,7 +2,24 @@ import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
+const config = {
+  thresholds: [
+    { l: 's', r: 1 },
+    { l: 'm', r: 1 },
+    { l: 'mm', r: 59, d: 'minute' },
+    { l: 'h', r: 1 },
+    { l: 'hh', r: 23, d: 'hour' },
+    { l: 'd', r: 1 },
+    { l: 'dd', r: 29, d: 'day' },
+    { l: 'M', r: 1 },
+    { l: 'MM', r: 11, d: 'month' },
+    { l: 'y', r: 1 },
+    { l: 'yy', d: 'year' }
+  ],
+  rounding: Math.floor
+}
+
 dayjs.extend(duration)
-dayjs.extend(relativeTime)
+dayjs.extend(relativeTime, config)
 
 export default dayjs


### PR DESCRIPTION
Fixes #1375

source: https://day.js.org/docs/en/customization/relative-time#relative-time-thresholds-and-rounding