### PR TITLE
fix(helpers): Rework toPrecision

### DIFF
--- a/src/helpers/data.spec.ts
+++ b/src/helpers/data.spec.ts
@@ -68,4 +68,7 @@ test('helpers/data/formatData', () => {
 
   expect(formatData(1024, false)).toBe('1.02 kB')
   expect(formatData(1024, true)).toBe('1.00 kiB')
+
+  expect(formatData(1052804121, true)).toBe('1004 MiB')
+  expect(formatData(1066436574, true)).toBe('1017 MiB')
 })

--- a/src/helpers/number.spec.ts
+++ b/src/helpers/number.spec.ts
@@ -11,6 +11,8 @@ test('helpers/number/toPrecision', () => {
   expect(toPrecision(10, 2)).toBe('10')
   expect(toPrecision(10, 1)).toBe('10')
 
+  expect(toPrecision(99.99, 3)).toBe('99.9')
+
   expect(toPrecision(100, 3)).toBe('100')
 })
 
@@ -18,4 +20,6 @@ test('helpers/number/formatPercent', () => {
   expect(formatPercent(0)).toBe('0.00 %')
   expect(formatPercent(0.1)).toBe('10.0 %')
   expect(formatPercent(1)).toBe('100 %')
+
+  expect(formatPercent(0.999942870757758)).toBe('99.9 %')
 })

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -1,12 +1,18 @@
 export function toPrecision(value: number, precision: number): string {
   if (value >= 10 ** precision) {
-    return value.toString()
-  }
-  if (value >= 1) {
-    return value.toPrecision(precision)
+    return Math.floor(value).toString()
   }
 
-  return value.toFixed(precision - 1)
+  const strValue = value.toFixed(precision)
+  if (strValue.length < Math.floor(Math.log10(value)) + 1) {
+    return strValue
+  } else {
+    const result = strValue.substring(0, precision + 1);
+    if (result.endsWith('.')) {
+      return result.slice(0, -1)
+    }
+    return result
+  }
 }
 
 export function formatPercent(progress: number): string {


### PR DESCRIPTION
This PR reworks the toPrecision helper function previously returning :
- rounded floating-point values for percentages
  - displays 100% progress on a downloading torrent which was misleading
- way too many decimals for binary values between 1000 and 1024

Before:
![image](https://github.com/WDaan/VueTorrent/assets/22910497/83868b09-2ddf-478b-8566-155be5b64094)

After:
![image](https://github.com/WDaan/VueTorrent/assets/22910497/42f8ad5b-fcb0-4c03-bb06-02258a7bcded)
