### PR TITLE
feat(logs): Prevent duplication and add message filter

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,7 @@ watch(
       appStore.pushInterval(() => maindataStore.updateMaindata(), vuetorrentStore.refreshInterval)
       await maindataStore.updateMaindata()
       await preferencesStore.fetchPreferences()
-      await logStore.fetchLogs()
+      await logStore.cleanAndFetchLogs()
       await maindataStore.fetchCategories()
       await maindataStore.fetchTags()
       addTorrentStore.initForm()

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -433,14 +433,8 @@
   "logs": {
     "emptyLogList": "No logs found",
     "filters": {
-      "sortBy": {
-        "id": "Log ID",
-        "label": "Sort by",
-        "message": "Message",
-        "timestamp": "Log Date",
-        "type": "Log Level"
-      },
-      "type": "Log Level"
+      "type": "Log Level",
+      "query": "Search in log message"
     },
     "title": "qBittorrent Logs"
   },

--- a/src/pages/Logs.vue
+++ b/src/pages/Logs.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useArrayPagination } from '@/composables'
+import { useArrayPagination, useSearchQuery } from '@/composables'
 import { LogType } from '@/constants/qbit'
 import { useLogStore, useVueTorrentStore } from '@/stores'
 import { Log } from '@/types/qbit/models'
@@ -15,12 +15,6 @@ const { t } = useI18n()
 const logStore = useLogStore()
 const vueTorrentStore = useVueTorrentStore()
 
-const headers = ref([
-  { title: t('logs.filters.sortBy.id'), value: 'id' },
-  { title: t('logs.filters.sortBy.type'), value: 'type' },
-  { title: t('logs.filters.sortBy.message'), value: 'message' },
-  { title: t('logs.filters.sortBy.timestamp'), value: 'timestamp' }
-])
 const logTypeOptions = ref([
   { title: LogType[LogType.NORMAL], value: LogType.NORMAL },
   { title: LogType[LogType.INFO], value: LogType.INFO },
@@ -28,10 +22,11 @@ const logTypeOptions = ref([
   { title: LogType[LogType.CRITICAL], value: LogType.CRITICAL }
 ])
 const logTypeFilter = ref<LogType[]>([LogType.NORMAL, LogType.INFO, LogType.WARNING, LogType.CRITICAL])
-const sortBy = ref(['id'])
+const query = ref('')
 
-const logs = computed(() => logStore.logs)
-const filteredLogs = computed(() => logs.value.filter(log => logTypeFilter.value.includes(log.type)))
+const logs = computed<Log[]>(() => logStore.logs)
+const filteredLogsByType = computed(() => logs.value.filter(log => logTypeFilter.value.includes(log.type)))
+const { results: filteredLogs } = useSearchQuery(filteredLogsByType, query, (log: Log) => log.message)
 const someTypesSelected = computed(() => logTypeFilter.value.length > 0)
 const allTypesSelected = computed(() => logTypeFilter.value.length === logTypeOptions.value.length)
 
@@ -104,7 +99,7 @@ onUnmounted(() => {
           </v-col>
 
           <v-col cols="6">
-            <v-select v-model="sortBy" :items="headers" :label="$t('logs.filters.sortBy.label')" hide-details multiple chips />
+            <v-text-field v-model="query" :label="$t('logs.filters.query')" hide-details />
           </v-col>
         </v-row>
       </v-list-item>

--- a/src/pages/Logs.vue
+++ b/src/pages/Logs.vue
@@ -41,7 +41,7 @@ const goHome = () => {
   router.push({ name: 'dashboard' })
 }
 const getLogTypeClassName = (log: Log) => {
-  return `logtype-${LogType[log?.type]?.toLowerCase()}`
+  return `logtype-${ LogType[log?.type]?.toLowerCase() }`
 }
 const getLogTypeName = (log: Log) => {
   return LogType[log.type]
@@ -62,10 +62,10 @@ const handleKeyboardShortcut = (e: KeyboardEvent) => {
   }
 }
 
-onBeforeMount(() => {
+onBeforeMount(async () => {
   document.addEventListener('keydown', handleKeyboardShortcut)
+  await logStore.cleanAndFetchLogs()
   useIntervalFn(logStore.fetchLogs, 15000)
-  logStore.fetchLogs(-1)
 })
 onUnmounted(() => {
   document.removeEventListener('keydown', handleKeyboardShortcut)


### PR DESCRIPTION
- Prevent log duplication
- Change unused sort to filter

Fixes #1282
Default sort order is still the same => in ascending order by log ID.
With the pagination in place, you can go to the last page with only one click. Moreover with the reversed sort order, each time logs are added it would shift the list by the added amount of logs which may be frustrating when looking at logs after some time.