### PR TITLE
sticking button bar in add torrent dialog to bottom of screen in mobile closes #1409

### DIFF
--- a/src/components/Dialogs/AddTorrentDialog.vue
+++ b/src/components/Dialogs/AddTorrentDialog.vue
@@ -417,14 +417,23 @@ const onCategoryChanged = () => {
         </v-row>
       </v-card-text>
 
-      <v-card-actions class="justify-center">
-        <v-btn :text="$t('dialogs.add.resetForm')" color="error" variant="flat" @click="addTorrentStore.resetForm()" />
+      <v-card-actions class="justify-center" :id="$vuetify.display.mobile ? 'sticky-card-actions' : ''">
+        <v-btn :text="$t('dialogs.add.resetForm')" color="warning" variant="flat" @click="addTorrentStore.resetForm()" />
         <v-spacer />
         <v-btn :disabled="!isFormValid" :text="$t('dialogs.add.submit')" color="accent" type="submit" variant="elevated" @click="submit" />
-        <v-btn :text="$t('common.close')" color="" variant="flat" @click="close" />
+        <v-btn :text="$t('common.close')" color="error" variant="flat" @click="close" />
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
-<style scoped></style>
+<style scoped>
+#sticky-card-actions {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: rgb(var(--v-theme-surface));
+  z-index: 1000;
+}
+</style>


### PR DESCRIPTION
# sticking button bar in add torrent dialog to bottom of screen in mobile closes #1409  [feat]

In add torrent dialog box (For mobile devices) we have to scroll to end of box just to click on add torrent button. to solve this, I have fixed the whole button bar to bottom of screen in mobile devices.

along with that also changed the color of buttons to reflect on the severity of the action of clicking that button on add torrent dialog box [if this doesn't align with spirit of project, we can revert that]

![image](https://github.com/WDaan/VueTorrent/assets/106881717/6a82f5c8-73fa-4351-9fad-c026afe5daed)
![image](https://github.com/WDaan/VueTorrent/assets/106881717/365c446d-59dd-4441-b1a0-ddc39acd834a)
![image](https://github.com/WDaan/VueTorrent/assets/106881717/c889118b-c266-408c-ada1-720d995f8ebd)


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
