### PR TITLE
fix(polyfills): Downgraded 'toSorted' polyfill to support older browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@vueuse/core": "^13.1.0",
         "@zip.js/zip.js": "^2.7.60",
         "apexcharts": "^4.5.0",
-        "array.prototype.tosorted": "^1.1.4",
+        "array.prototype.tosorted": "1.1.3",
         "axios": "^1.8.4",
         "dayjs": "^1.11.13",
         "lodash.debounce": "^4.0.8",
@@ -3276,19 +3276,16 @@
       }
     },
     "node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz",
+      "integrity": "sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.1.0",
         "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@vueuse/core": "^13.1.0",
     "@zip.js/zip.js": "^2.7.60",
     "apexcharts": "^4.5.0",
-    "array.prototype.tosorted": "^1.1.4",
+    "array.prototype.tosorted": "1.1.3",
     "axios": "^1.8.4",
     "dayjs": "^1.11.13",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Fix #2130
The latest version of 'toSorted' may report an assertion error (https://github.com/es-shims/Array.prototype.toSorted/issues/4), and it needs to be downgraded to version 1.1.3 to fix issue. 

I have successfully tested it on iOS 15.7.1