### PR TITLE
fix(filters): Fix trackers filter not working in some cases

### DIFF
--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -160,7 +160,7 @@ export const useTorrentStore = defineStore(
         case FilterType.CONJUNCTIVE:
           return Array.from(trackerFilter.include).every(matcher) && Array.from(trackerFilter.exclude).every(t => !matcher(t))
         case FilterType.DISJUNCTIVE:
-          return Array.from(trackerFilter.include).some(matcher) && Array.from(trackerFilter.exclude).some(t => !matcher(t))
+          return Array.from(trackerFilter.include).some(matcher) || Array.from(trackerFilter.exclude).some(t => !matcher(t))
       }
     }
 


### PR DESCRIPTION
Filter is not working when using only one of include or exclude trackers in disjunctive (OR) mode.