### PR TITLE
fix(Dashboard): Add min height for main container

### DIFF
--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -43,7 +43,7 @@ const height = computed(() => {
   // 48px for the multiple selection row
   // 8px for the pagination margin
   // 58px for the bottom pagination
-  return (
+  return Math.max(150,
     deviceHeight.value -
     64 -
     8 -


### PR DESCRIPTION
Prevent landscape mobile dashboard from showing such a small space with the fixed height.

User can scroll to show more of the torrent list. No changes on desktop and portrait orientation.

Before
![image](https://github.com/user-attachments/assets/a26ade23-ca70-4acf-96a1-623961140204)

After
![image](https://github.com/user-attachments/assets/4797d4e7-825b-43da-98c3-07d75d1f44c2)
