### PR TITLE
perf(search engine): Add button to append to queue on qbit 5.X

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -730,7 +730,12 @@
     "runSearch": "Search",
     "stopSearch": "Stop",
     "tabHeaderEmpty": "(Empty query)",
-    "title": "Search engine"
+    "title": "Search engine",
+    "tooltip": {
+      "open_link": "Open link in new tab",
+      "append_queue": "Append to torrent queue",
+      "download": "Download using plugin"
+    }
   },
   "settings": {
     "addons": {

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -81,13 +81,12 @@ function deleteTab() {
   tabIndex.value = Math.min(tabIndex.value, searchData.value.length - 1)
 }
 
-function downloadTorrent(result: SearchResult) {
-  if (appStore.usesQbit5) {
-    searchEngineStore.downloadTorrent(result.fileUrl, result.engineName!)
-  } else {
-    addTorrentStore.pushTorrentToQueue(result.fileUrl)
-  }
+function pushToQueue(result: SearchResult) {
+  addTorrentStore.pushTorrentToQueue(result.fileUrl)
+}
 
+function downloadTorrent(result: SearchResult) {
+  searchEngineStore.downloadTorrent(result.fileUrl, result.engineName!)
   result.downloaded = true
 }
 
@@ -285,7 +284,9 @@ onBeforeUnmount(() => {
               </v-col>
               <v-col cols="3" class="item-actions">
                 <v-btn icon="mdi-open-in-new" variant="flat" density="compact" @click.stop="openResultLink(item)" />
+                <v-btn icon="mdi-plus-box-multiple" variant="text" density="compact" @click="pushToQueue(item)" />
                 <v-btn
+                  v-if="appStore.usesQbit5"
                   :icon="item.downloaded ? 'mdi-check' : 'mdi-download'"
                   :color="item.downloaded && 'accent'"
                   variant="text"
@@ -316,8 +317,30 @@ onBeforeUnmount(() => {
             {{ value === -1 ? t('common.NA') : formatTimeSec(value, dateFormat) }}
           </template>
           <template v-slot:[`item.actions`]="{ item }">
-            <v-btn icon="mdi-open-in-new" variant="flat" density="compact" @click.stop="openResultLink(item)" />
-            <v-btn :icon="item.downloaded ? 'mdi-check' : 'mdi-download'" :color="item.downloaded && 'accent'" variant="text" density="compact" @click="downloadTorrent(item)" />
+            <v-tooltip :text="$t('searchEngine.tooltip.open_link')" location="top">
+              <template v-slot:activator="{ props }">
+                <v-btn v-bind="props" icon="mdi-open-in-new" variant="flat" density="compact" @click.stop="openResultLink(item)" />
+              </template>
+            </v-tooltip>
+
+            <v-tooltip :text="$t('searchEngine.tooltip.append_queue')" location="top">
+              <template v-slot:activator="{ props }">
+                <v-btn v-bind="props" icon="mdi-plus-box-multiple" variant="text" density="compact" @click="pushToQueue(item)" />
+              </template>
+            </v-tooltip>
+
+            <v-tooltip :text="$t('searchEngine.tooltip.download')" location="top">
+              <template v-slot:activator="{ props }">
+                <v-btn
+                  v-if="appStore.usesQbit5"
+                  v-bind="props"
+                  :icon="item.downloaded ? 'mdi-check' : 'mdi-download'"
+                  :color="item.downloaded && 'accent'"
+                  variant="text"
+                  density="compact"
+                  @click="downloadTorrent(item)" />
+              </template>
+            </v-tooltip>
           </template>
         </v-data-table>
       </v-list-item>

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -1078,7 +1078,9 @@ export default class MockProvider implements IProvider {
             fileUrl: 'https://www.example.com/torrent/SDb4v2op8wm',
             nbLeechers: 0,
             nbSeeders: 0,
-            siteUrl: 'https://www.example.com'
+            siteUrl: 'https://www.example.com',
+            engineName: 'Example',
+            pubDate: new Date().getTime() / 1000
           }
         ],
         status: 'Stopped',


### PR DESCRIPTION
Adds a button in result row if qbit 5.X is detected to download using search plugin (old behaviour).

The first two are always displayed.

![image](https://github.com/user-attachments/assets/0d4c2306-afd3-49b4-ad19-d4f4a4651e2c)

Fixes #2030 
