### PR TITLE
perf(Right Click Menu): Hold Ctrl/Cmd to keep menu open after click

### DIFF
--- a/src/components/Core/RightClickMenu/RightClickMenu.vue
+++ b/src/components/Core/RightClickMenu/RightClickMenu.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { isMac } from '@/helpers'
 import RightClickMenuEntry from './RightClickMenuEntry.vue'
+import { useKeyModifier } from '@vueuse/core'
 import { RightClickMenuEntryType } from '@/types/vuetorrent'
 
 defineProps<{
@@ -7,11 +9,14 @@ defineProps<{
 }>()
 
 const rightClickMenuVisible = defineModel<boolean>({ required: true })
+
+const isCtrlPressed = useKeyModifier(isMac ? 'Meta' : 'Control', { initial: false })
 </script>
 
 <template>
-  <v-menu v-if="rightClickMenuVisible" v-model="rightClickMenuVisible" activator="parent" close-on-content-click transition="slide-y-transition" scroll-strategy="none">
+  <v-menu v-if="rightClickMenuVisible" v-model="rightClickMenuVisible" activator="parent" :close-on-content-click="!isCtrlPressed" transition="slide-y-transition" scroll-strategy="none">
     <v-list>
+      <v-list-item>close-on-content-click: {{ !isCtrlPressed }}</v-list-item>
       <slot name="top" />
       <v-divider v-if="$slots.top" thickness="3" />
 

--- a/src/components/Core/RightClickMenu/RightClickMenuEntry.vue
+++ b/src/components/Core/RightClickMenu/RightClickMenuEntry.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { isMac } from '@/helpers'
 import { RightClickMenuEntryType } from '@/types/vuetorrent'
+import { useKeyModifier } from '@vueuse/core'
 
 const props = defineProps<{
   entryData: RightClickMenuEntryType
 }>()
+
+const isCtrlPressed = useKeyModifier(isMac ? 'Meta' : 'Control', { initial: false })
 
 const onClick = () => {
   if (props.entryData.action) {
@@ -22,7 +26,7 @@ const onClick = () => {
       <v-spacer />
       <v-icon v-if="!entryData.disabled && entryData.children">mdi-chevron-right</v-icon>
     </div>
-    <v-menu v-if="entryData.children" activator="parent" open-on-hover open-on-click close-delay="10" open-delay="0" location="right">
+    <v-menu v-if="entryData.children" activator="parent" open-on-hover open-on-click :close-on-content-click="!isCtrlPressed" close-delay="10" open-delay="0" location="right">
       <v-list>
         <template v-if="entryData.slots?.top">
           <RightClickMenuEntry v-for="slotData in entryData.slots.top" :entryData="slotData" />


### PR DESCRIPTION
Reported on Discord, holding Ctrl/Cmd will prevent Vuetify from closing the menu on click.

Useful when applying multiple flags in Advanced or setting multiple tags quickly.