### PR TITLE
feat(ui): widen dropdown menu scrollbar

### DIFF
--- a/src/components/Dashboard/Toolbar.vue
+++ b/src/components/Dashboard/Toolbar.vue
@@ -138,7 +138,6 @@ function toggleSelectMode() {
         :label="t('dashboard.sortLabel')"
         density="compact"
         hide-details
-        :menu-props="{ contentClass: 'wide-scrollbar' }"
         variant="solo-filled"
         :style="`width: ${$vuetify.display.xs || ($vuetify.display.sm && isDrawerOpen) ? 140 : 260}px`" />
     </div>


### PR DESCRIPTION
# feat(ui): widen dropdown menu scrollbar

Widen scrollbars inside menus list.

Before :
![image](https://github.com/user-attachments/assets/fb20b268-ba17-43e3-ae99-17490bb79e1c)
After :
![image](https://github.com/user-attachments/assets/fecf94f8-edfe-455c-a98f-bf81849230e4)

Incompatible to Firefox, check https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar#browser_compatibility

Related issue  Fix #2183

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
