### PR TITLE
feat(Overview): Show all pieces state when clicking on the canvas

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1371,6 +1371,9 @@
       "downloaded": "Downloaded",
       "fetchingMetadata": "Fetching...",
       "fileCount": "Selected Files",
+      "piece_canvas_dialog": {
+        "title": "Piece state oveview"
+      },
       "pieceCount": "{owned} / {total} ({pieceSize})",
       "ratio": "Ratio",
       "selectedFileSize": "Selected Files' Size",


### PR DESCRIPTION
When clicking on the piece canvas, a new dialog will show up highlighting all current piece states in detail.

Tested with 15k+ pieces and no lags were noticed on both desktop and mobile.

![image](https://github.com/user-attachments/assets/4132eb1a-ad24-4dc5-9383-1bf8766bf83e)


![image](https://github.com/user-attachments/assets/08f1345e-4710-473a-b0fc-b4945c32280c)

Piece colors are based on torrent state colors:
- Grey means piece is missing
- Green means piece is downloading
- Blue means piece is completely downloaded