### PR TITLE
[Feat] Fixing compatibility with password managers

### DIFF
--- a/src/components/Core/PasswordField.vue
+++ b/src/components/Core/PasswordField.vue
@@ -2,14 +2,14 @@
 import { computed, ref } from 'vue'
 
 defineProps<{
-    hideIcon?: boolean
-    prependIcon?: string
+  hideIcon?: boolean
+  prependIcon?: string
 }>()
 
 const showPassword = ref(false)
 
 function toggleShow() {
-    showPassword.value = !showPassword.value
+  showPassword.value = !showPassword.value
 }
 
 const type = computed(() => (showPassword.value ? 'text' : 'password'))
@@ -18,10 +18,10 @@ const icon = computed(() => (showPassword.value ? 'mdi-eye' : 'mdi-eye-off'))
 
 <template>
   <v-text-field name="password" :type="type" :append-inner-icon="hideIcon ? '' : icon" @click:append-inner="toggleShow">
-        <template v-if="prependIcon" #prepend>
-            <v-icon color="accent" :icon="prependIcon" />
-        </template>
-    </v-text-field>
+    <template v-if="prependIcon" #prepend>
+      <v-icon color="accent" :icon="prependIcon" />
+    </template>
+  </v-text-field>
 </template>
 
 <style scoped></style>

--- a/src/components/Settings/WebUI.vue
+++ b/src/components/Settings/WebUI.vue
@@ -72,7 +72,12 @@ function registerDynDNS() {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field v-model="preferenceStore.preferences!.web_ui_username" autocomplete="username" aria-autocomplete="username" hide-details :label="t('settings.webUI.authentication.username')" />
+          <v-text-field
+            v-model="preferenceStore.preferences!.web_ui_username"
+            autocomplete="username"
+            aria-autocomplete="username"
+            hide-details
+            :label="t('settings.webUI.authentication.username')" />
         </v-col>
         <v-col cols="12" sm="6">
           <PasswordField

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -70,32 +70,32 @@ watchEffect(() => {
       <v-card-subtitle>{{ t('login.subtitle') }}</v-card-subtitle>
       <v-card-text>
         <v-form v-model="rulesOk" @submit.prevent="login">
-            <v-text-field
-                id="username"
-                v-model="loginForm.username"
-                name="username"
-                autocomplete="username"
-                aria-autocomplete="username"
-                :label="t('login.username')"
-                autofocus
-                :rules="rules.username"
-                variant="outlined"
-                @keydown.enter.prevent="login">
-                <template #prepend>
-                    <v-icon color="accent" icon="mdi-account" />
-                </template>
-            </v-text-field>
+          <v-text-field
+            id="username"
+            v-model="loginForm.username"
+            name="username"
+            autocomplete="username"
+            aria-autocomplete="username"
+            :label="t('login.username')"
+            autofocus
+            :rules="rules.username"
+            variant="outlined"
+            @keydown.enter.prevent="login">
+            <template #prepend>
+              <v-icon color="accent" icon="mdi-account" />
+            </template>
+          </v-text-field>
 
-            <PasswordField
-                id="password"
-                v-model="loginForm.password"
-                autocomplete="current-password"
-                aria-autocomplete="current-password"
-                :label="t('login.password')"
-                :rules="rules.password"
-                prepend-icon="mdi-lock"
-                variant="outlined"
-                @keydown.enter.prevent="login" />
+          <PasswordField
+            id="password"
+            v-model="loginForm.password"
+            autocomplete="current-password"
+            aria-autocomplete="current-password"
+            :label="t('login.password')"
+            :rules="rules.password"
+            prepend-icon="mdi-lock"
+            variant="outlined"
+            @keydown.enter.prevent="login" />
         </v-form>
       </v-card-text>
       <v-card-actions>


### PR DESCRIPTION
# [Feat] Fixing compatibility with password managers

## Fix for Issue #2358, #1504*

### `src -> pages -> Login.vue -> template -> v-container -> v-card -> v-card-text`

**Changes made**:
Added `autocomplete`, `aria-autocomplete`, and `type` attributes to the username and password fields in the login form to align with expected autofill standards.

**Purpose**:
To improve compatibility with browser-based and third-party password managers (e.g. KeePassXC-Browser, BitWarden, Google Password Manager) by making use of the Chromium & Aria autofill standards and ensuring the DOM identifies the Password Field as the password type.

```diff
<v-form v-model="rulesOk" @submit.prevent="login">
-   <v-text-field
-       id="username"
-       v-model="loginForm.username"
-       name="username"
-       :label="t('login.username')"
-       autofocus
-       :rules="rules.username"
-       variant="outlined"
-       @keydown.enter.prevent="login">
+   <v-text-field
+       id="username"
+       v-model="loginForm.username"
+       name="username"
+       autocomplete="username"
+       aria-autocomplete="username"
+       :label="t('login.username')"
+       autofocus
+       :rules="rules.username"
+       variant="outlined"
+       @keydown.enter.prevent="login">
        <template #prepend>
            <v-icon color="accent" icon="mdi-account" />
        </template>
    </v-text-field>

-   <PasswordField
-       id="password"
-       v-model="loginForm.password"
-       :label="t('login.password')"
-       :rules="rules.password"
-       prepend-icon="mdi-lock"
-       variant="outlined"
-       @keydown.enter.prevent="login" />
+   <PasswordField
+       id="password"
+       v-model="loginForm.password"
+       autocomplete="current-password"
+       aria-autocomplete="current-password"
+       type="password"
+       :label="t('login.password')"
+       :rules="rules.password"
+       prepend-icon="mdi-lock"
+       variant="outlined"
+       @keydown.enter.prevent="login" />
</v-form>
```

### `src -> components -> core -> PasswordField.vue`

**Changes Made**:
The component was updated to forward all parent-provided attributes (`v-model`, `name`, `id`, `autocomplete`, etc.) using `useAttrs()` and `v-bind="attrs"` on the inner `<v-text-field>`.

**Purpose**:
To improve compatibility with form handling and password managers' detection & modification algorithms by ensuring neccesary HTML attribute are passed to the actual `<input>` DOM element. Also increases the reusability and flexibility of the component by rearranging the structure.

```diff
<script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, useAttrs } from 'vue'

 defineProps<{
-  hideIcon?: boolean
-  prependIcon?: string
+    hideIcon?: boolean
+    prependIcon?: string
 }>()

+const attrs = useAttrs()
 const showPassword = ref(false)

 function toggleShow() {
     showPassword.value = !showPassword.value
 }

 const type = computed(() => (showPassword.value ? 'text' : 'password'))
 const icon = computed(() => (showPassword.value ? 'mdi-eye' : 'mdi-eye-off'))
</script>

<template>
-  <v-text-field name="password" :type="type" :append-inner-icon="hideIcon ? '' : icon" @click:append-inner="toggleShow">
+  <v-text-field
+      v-bind="attrs"
+      name="password"
+      :type="type"
+      :append-inner-icon="hideIcon ? '' : icon"
+      @click:append-inner="toggleShow"
+  >
-    <template v-slot:prepend v-if="prependIcon">
+    <template v-if="prependIcon" #prepend>
         <v-icon color="accent" :icon="prependIcon" />
     </template>
   </v-text-field>
</template>
```

### Additional Information

This was tested as a fix specifically for **KeePassXC-Browser** and **Google Password Manager**. Additional tests needed to determine if the fix is appliable to **BitWarden**, **NordPass**, and **LastPass**.

*More testing is required to determine if the fix works properly with BitWarden, as originally addressed with Issue #1504.
*Extension issues with KeePassXC-Browser may require you to hit `Redetect Login Fields` manually for it to detect the passwords.

### Screenshots
![image](https://github.com/user-attachments/assets/88d3abb2-626d-4c68-b53e-2481b4403b6d)

### PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
