### PR TITLE
fix: PWA app respects Device Rotation lock

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -35,7 +35,6 @@
     "client_mode": "focus-existing"
   },
   "name": "VueTorrent",
-  "orientation": "any",
   "protocol_handlers": [
     {
       "protocol": "magnet",


### PR DESCRIPTION
# PWA app respects Device Rotation lock [fix]

PWA app ignores the devices app orientation and rotates when ever i tilt my phone even though the device is locked.
this PR fixes that issue by removing orientation from webmanifest file and let the Underlying browser handle the Rotation which respects the Device settings. will be attaching POT as comment

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
