### PR TITLE
fix(long press): Prevent selecting text on mobile devices

### DIFF
--- a/src/components/Dashboard/Views/Grid/GridView.vue
+++ b/src/components/Dashboard/Views/Grid/GridView.vue
@@ -25,14 +25,14 @@ const dashboardStore = useDashboardStore()
     <v-col
       v-for="torrent in paginatedTorrents"
       :key="torrent.hash"
-      v-on-long-press="e => $emit('onTorrentRightClick', e, torrent)"
+      v-on-long-press.prevent="e => $emit('onTorrentRightClick', e, torrent)"
+      data-custom-context-menu
       cols="12"
       lg="3"
       md="4"
       sm="6"
       xl="2"
       class="pb-0"
-      data-custom-context-menu
       @contextmenu="$emit('onTorrentRightClick', $event, torrent)"
       @dblclick="$emit('onTorrentDblClick', torrent)">
       <div class="d-flex align-center" style="height: 100%; width: 100%">

--- a/src/components/Dashboard/Views/List/ListView.vue
+++ b/src/components/Dashboard/Views/List/ListView.vue
@@ -28,9 +28,9 @@ const dashboardStore = useDashboardStore()
       v-for="torrent in paginatedTorrents"
       :id="`torrent-${torrent.hash}`"
       :key="torrent.hash"
-      v-on-long-press="e => $emit('onTorrentRightClick', e, torrent)"
-      :class="['pa-0', display.mobile ? 'mb-2' : 'mb-4']"
+      v-on-long-press.prevent="e => $emit('onTorrentRightClick', e, torrent)"
       data-custom-context-menu
+      :class="['pa-0', display.mobile ? 'mb-2' : 'mb-4']"
       @contextmenu="$emit('onTorrentRightClick', $event, torrent)"
       @dblclick="$emit('onTorrentDblClick', torrent)">
       <div class="d-flex align-center">

--- a/src/components/Dashboard/Views/Table/TableView.vue
+++ b/src/components/Dashboard/Views/Table/TableView.vue
@@ -84,9 +84,9 @@ function getTorrentRowColorClass(torrent: TorrentType) {
     <template #item="{ item: torrent }">
       <tr
         v-ripple
-        v-on-long-press="e => $emit('onTorrentRightClick', e, torrent)"
-        :class="['cursor-pointer', 'selected', 'ripple-fix', getTorrentRowColorClass(torrent)]"
+        v-on-long-press.prevent="e => $emit('onTorrentRightClick', e, torrent)"
         data-custom-context-menu
+        :class="['cursor-pointer', 'selected', 'ripple-fix', getTorrentRowColorClass(torrent)]"
         @contextmenu="$emit('onTorrentRightClick', $event, torrent)"
         @click="$emit('onTorrentClick', $event, torrent)"
         @dblclick="$emit('onTorrentDblClick', torrent)">

--- a/src/components/Navbar/SideWidgets/FilterSelectMulti.vue
+++ b/src/components/Navbar/SideWidgets/FilterSelectMulti.vue
@@ -122,10 +122,10 @@ function disableFilter(value: T) {
       </template>
       <template #item="{ item }">
         <v-list-item
-          v-on-long-press="() => disableFilter(item.value)"
+          v-on-long-press.prevent="() => disableFilter(item.value)"
+          data-custom-context-menu
           :title="item.title"
           :class="getClassColor(item.value)"
-          data-custom-context-menu
           @click="toggleValue(item.value)"
           @contextmenu="disableFilter(item.value)">
           <template #prepend>

--- a/src/components/RSS/Feeds/Article.vue
+++ b/src/components/RSS/Feeds/Article.vue
@@ -19,9 +19,9 @@ const rssStore = useRssStore()
 
 <template>
   <v-list-item
-    v-on-long-press="() => $emit('markAsRead')"
-    :class="{ 'rss-read': value.isRead }"
+    v-on-long-press.prevent="() => $emit('markAsRead')"
     data-custom-context-menu
+    :class="{ 'rss-read': value.isRead }"
     @click="$emit('click')"
     @contextmenu="$emit('markAsRead')">
     <div class="d-flex">

--- a/src/components/TorrentDetail/Content/ContentNode.vue
+++ b/src/components/TorrentDetail/Content/ContentNode.vue
@@ -91,10 +91,10 @@ function getNodeSubtitle(node: TreeNode) {
 
 <template>
   <div
-    v-on-long-press="e => $emit('onRightClick', e, node)"
+    v-on-long-press.prevent="e => $emit('onRightClick', e, node)"
+    data-custom-context-menu
     :class="['d-flex flex-column py-2 pr-3', node.isSelected(internalSelection) ? 'selected' : '']"
     :style="`padding-left: ${depth}px`"
-    data-custom-context-menu
     @click.stop="toggleInternalSelection($event, node)"
     @contextmenu="$emit('onRightClick', $event, node)">
     <div class="d-flex">


### PR DESCRIPTION
Fixes #2391

This bug only appears on Safari due to the way they handle right click on mobile. I don't have any Apple mobile so it wasn't caught during testing, I hope this is enough to fix the issue.