### PR TITLE
feat(content): Display node availability

### DIFF
--- a/src/components/TorrentDetail/Content/ContentNode.vue
+++ b/src/components/TorrentDetail/Content/ContentNode.vue
@@ -5,7 +5,7 @@ import { computed, triggerRef } from 'vue'
 import { useDisplay } from 'vuetify'
 import { useI18nUtils } from '@/composables'
 import { FilePriority } from '@/constants/qbit'
-import { doesCommand, formatData, getFileIcon } from '@/helpers'
+import { doesCommand, formatData, getFileIcon, formatPercent } from '@/helpers'
 import { useContentStore, useVueTorrentStore } from '@/stores'
 import { TreeNode } from '@/types/vuetorrent'
 
@@ -95,6 +95,7 @@ function getNodeSubtitle(node: TreeNode) {
     data-custom-context-menu
     :class="['d-flex flex-column py-2 pr-3', node.isSelected(internalSelection) ? 'selected' : '']"
     :style="`padding-left: ${depth}px`"
+    :title="`${formatPercent(node.progress)} / ${formatPercent(node.availability)}`"
     @click.stop="toggleInternalSelection($event, node)"
     @contextmenu="$emit('onRightClick', $event, node)">
     <div class="d-flex">
@@ -141,7 +142,8 @@ function getNodeSubtitle(node: TreeNode) {
         <v-icon v-else-if="node.priority === FilePriority.DO_NOT_DOWNLOAD" color="grey"> mdi-cancel </v-icon>
       </div>
     </div>
-    <v-progress-linear :model-value="node.progress" :max="1" :color="getNodeColor(node)" rounded="sm" />
+
+    <v-progress-linear :model-value="node.progress" max="1" :color="getNodeColor(node)" rounded="sm" :buffer-value="node.availability" buffer-color="accent" buffer-opacity=".5" />
   </div>
 </template>
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,7 +3,7 @@ import comparators, { Comparator, isObjectEqual } from './comparators'
 import { formatData, formatDataUnit, formatDataValue } from './data'
 import { formatDuration, formatEta, formatTimeMs, formatTimeSec } from './datetime'
 import { arrayRemove } from './misc'
-import { formatPercent, toPrecision } from './number'
+import { formatPercent, toPrecision, safeDiv } from './number'
 import { basename, getExtType, getFileIcon, getTypeIcon, splitExt } from './path'
 import { formatSpeed, formatSpeedUnit, formatSpeedValue } from './speed'
 import { doesCommand, downloadFile, isMac, isWindows, openLink } from './system'
@@ -26,6 +26,7 @@ export {
   arrayRemove,
   toPrecision,
   formatPercent,
+  safeDiv,
   basename,
   splitExt,
   getFileIcon,

--- a/src/helpers/number.spec.ts
+++ b/src/helpers/number.spec.ts
@@ -1,25 +1,35 @@
 import { expect, test } from 'vitest'
-import { formatPercent, toPrecision } from './number'
+import { formatPercent, toPrecision, safeDiv } from './number'
 
-test('helpers/number/toPrecision', () => {
-  expect(toPrecision(0, 3)).toBe('0.00')
-  expect(toPrecision(0.1, 3)).toBe('0.10')
+describe('helpers/number', () => {
+  test('toPrecision', () => {
+    expect(toPrecision(0, 3)).toBe('0.00')
+    expect(toPrecision(0.1, 3)).toBe('0.10')
 
-  expect(toPrecision(1, 3)).toBe('1.00')
+    expect(toPrecision(1, 3)).toBe('1.00')
 
-  expect(toPrecision(10, 3)).toBe('10.0')
-  expect(toPrecision(10, 2)).toBe('10')
-  expect(toPrecision(10, 1)).toBe('10')
+    expect(toPrecision(10, 3)).toBe('10.0')
+    expect(toPrecision(10, 2)).toBe('10')
+    expect(toPrecision(10, 1)).toBe('10')
 
-  expect(toPrecision(99.99, 3)).toBe('99.9')
+    expect(toPrecision(99.99, 3)).toBe('99.9')
 
-  expect(toPrecision(100, 3)).toBe('100')
-})
+    expect(toPrecision(100, 3)).toBe('100')
+  })
 
-test('helpers/number/formatPercent', () => {
-  expect(formatPercent(0)).toBe('0.00 %')
-  expect(formatPercent(0.1)).toBe('10.0 %')
-  expect(formatPercent(1)).toBe('100 %')
+  test('formatPercent', () => {
+    expect(formatPercent(0)).toBe('0.00 %')
+    expect(formatPercent(0.1)).toBe('10.0 %')
+    expect(formatPercent(1)).toBe('100 %')
 
-  expect(formatPercent(0.999942870757758)).toBe('99.9 %')
+    expect(formatPercent(0.999942870757758)).toBe('99.9 %')
+  })
+
+  test('safeDiv', () => {
+    expect(safeDiv(1, 1)).toBe(1)
+    expect(safeDiv(0, 1)).toBe(0)
+    expect(safeDiv(1, 0)).toBe(0)
+    expect(safeDiv(0, 0)).toBe(0)
+    expect(safeDiv(10, 10)).toBe(1)
+  })
 })

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -19,3 +19,8 @@ export function toPrecision(value: number, precision: number): string {
 export function formatPercent(progress: number): string {
   return `${toPrecision(progress * 100, 3)} %`
 }
+
+export function safeDiv(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0
+  return a / b
+}

--- a/src/types/vuetorrent/TreeObjects.ts
+++ b/src/types/vuetorrent/TreeObjects.ts
@@ -1,4 +1,5 @@
 import { FilePriority } from '@/constants/qbit'
+import { safeDiv } from '@/helpers'
 import { TorrentFile } from '@/types/qbit/models'
 
 export type TreeNode = TreeFile | TreeFolder
@@ -69,6 +70,7 @@ export class TreeFolder {
   wanted: boolean | null = null
   allWanted: boolean | null = null
   progress: number = 0
+  availability: number = 0
   deepCount: [number, number] = [1, 0]
   size: number = 0
   selectedSize: number = 0
@@ -88,6 +90,7 @@ export class TreeFolder {
       this.wanted = null
       this.allWanted = null
       this.progress = 0
+      this.availability = 0
       this.deepCount = [1, 0]
       this.size = 0
       this.selectedSize = 0
@@ -113,10 +116,15 @@ export class TreeFolder {
     const wantedChildren = this.children.filter(child => child.wanted)
     if (wantedChildren.length === 0) {
       this.progress = 0
+      this.availability = 0
     } else {
       // Downloaded / total
-      const result = wantedChildren.reduce((prev, child) => [prev[0] + child.selectedSize * child.progress, prev[1] + child.selectedSize], [0, 0])
-      this.progress = result[0] / result[1]
+      const progressResult: [number, number] = wantedChildren.reduce((prev, child) => [prev[0] + child.selectedSize * child.progress, prev[1] + child.selectedSize], [0, 0])
+      this.progress = safeDiv(...progressResult)
+
+      // Available / total
+      const availabilityResult: [number, number] = wantedChildren.reduce((prev, child) => [prev[0] + child.selectedSize * child.availability, prev[1] + child.selectedSize], [0, 0])
+      this.availability = safeDiv(...availabilityResult)
     }
 
     this.deepCount = this.children


### PR DESCRIPTION
Availability is now displayed in the progress bar using the accent color.

Also added a popover text to display "downloaded progress / availability" as percentage values.

<img width="554" height="90" alt="image" src="https://github.com/user-attachments/assets/d2cafba2-a7a8-4575-ba0d-aba61c1211f2" />
