### PR TITLE
fix(navbar): Swap alltime / session values to match popover text

### DIFF
--- a/src/components/Navbar/SideWidgets/TransferStats.vue
+++ b/src/components/Navbar/SideWidgets/TransferStats.vue
@@ -13,13 +13,13 @@ const maindataStore = useMaindataStore()
     <DataCard
       orientation="row"
       :title="t('navbar.side.transfer_stats.download')"
-      :value="[maindataStore.serverState?.alltime_dl ?? 0, maindataStore.serverState?.dl_info_data ?? 0]"
+      :value="[maindataStore.serverState?.dl_info_data ?? 0, maindataStore.serverState?.alltime_dl ?? 0]"
       color="download"
       icon="mdi-download" />
     <DataCard
       orientation="row"
       :title="t('navbar.side.transfer_stats.upload')"
-      :value="[maindataStore.serverState?.alltime_ul ?? 0, maindataStore.serverState?.up_info_data ?? 0]"
+      :value="[maindataStore.serverState?.up_info_data ?? 0, maindataStore.serverState?.alltime_ul ?? 0]"
       color="upload"
       icon="mdi-upload" />
   </StatSection>


### PR DESCRIPTION
Display session over alltime values in transfer stats section to better match popover title description