### PR TITLE
fix(Info): Remove clamping of long text values

### DIFF
--- a/src/components/TorrentDetail/Info/PanelLongText.vue
+++ b/src/components/TorrentDetail/Info/PanelLongText.vue
@@ -28,7 +28,7 @@ const values = [
     <v-expansion-panel-text>
       <v-list>
         <v-list-item v-for="ppt in values" :key="ppt.title" :title="$t(`torrent.properties.${ppt.title}`)">
-          <v-list-item-subtitle class="disable-line-clamp">{{ ppt.getter() || $t('common.none') }}</v-list-item-subtitle>
+          <div class="text-subtitle-2 opacity-70">{{ ppt.getter() || $t('common.none') }}</div>
         </v-list-item>
 
         <v-list-item :title="$t('torrent.properties.tags')">
@@ -43,10 +43,3 @@ const values = [
     </v-expansion-panel-text>
   </v-expansion-panel>
 </template>
-
-<style scoped>
-.disable-line-clamp {
-  line-clamp: none;
-  -webkit-line-clamp: none;
-}
-</style>


### PR DESCRIPTION
Prevent hidding long text values when it exceeds 1 line, like magnet link on mobile for example.

This prevented data being copied.

Discussed in #2411