### PR TITLE
fix(Content): Broken right click menu

### DIFF
--- a/src/components/TorrentDetail/Content/Content.vue
+++ b/src/components/TorrentDetail/Content/Content.vue
@@ -32,11 +32,11 @@ async function onRightClick(e: MouseEvent, node: TreeNode) {
     await nextTick()
   }
 
-  rightClickProperties.value = {
-    target: props.torrent.hash,
+  Object.assign(rightClickProperties.value, {
+    target: node.fullName,
     isVisible: true,
     offset: [e.pageX, e.pageY],
-  }
+  })
 
   if (internalSelection.value.size <= 1) {
     internalSelection.value = new Set([node.fullName])


### PR DESCRIPTION
Fixes #2433 

Some weird things happen with the `storeToRefs` calls, which breaks reactivity somehow.
`rightClickProperties` does return a Ref but `rightClickProperties.value` returns the underlying reactive object. Because we replace it, I guess the ref effect isn't triggered properly, rightClickProperties become unstable and isn't propagated to other component as it should, thus causing the error.