### PR TITLE
feat(SearchQuery): Match regex if enclosed with slashes

### DIFF
--- a/src/composables/SearchQuery.spec.ts
+++ b/src/composables/SearchQuery.spec.ts
@@ -81,4 +81,10 @@ describe('composables/SearchQuery', () => {
     expect(res3.value).toEqual([ITEM_WITHOUT_ACCENTS])
     expect(res4.value).toEqual([AZERTY])
   })
+
+  test('should test for regex if value enclosed with slashes', () => {
+    const items = ['abc123', 'def456']
+    const { results } = useSearchQuery(items, '/\\d+/', item => item)
+    expect(results.value).toEqual(items)
+  })
 })

--- a/src/composables/SearchQuery.ts
+++ b/src/composables/SearchQuery.ts
@@ -9,13 +9,20 @@ export function useSearchQuery<T>(
 ) {
   const results = computed(() => {
     const searchItems = toValue(items) ?? []
-    const tokens = normalize(toValue(searchQuery) ?? '')
-      .trim()
-      .split(/[ ,]/i)
-      .filter(Boolean)
-    const inclusionTokens = tokens.filter(token => !token.startsWith('-'))
-    const exclusionTokens = tokens.filter(token => token.startsWith('-')).map(token => token.slice(1))
-    const res = searchItems.filter(item => handleIncludeTokens(item, inclusionTokens) && handleExcludeTokens(item, exclusionTokens))
+    const query = toValue(searchQuery) ?? ''
+
+    let res: T[]
+
+    if (query.startsWith('/') && query.endsWith('/')) {
+      const regex = new RegExp(query.substring(1, query.length - 2))
+      res = searchItems.filter(item => [getter(item)].flat().some(singleItem => regex.test(singleItem)))
+    } else {
+      const tokens = normalize(query).trim().split(/[ ,]/i).filter(Boolean)
+      const inclusionTokens = tokens.filter(token => !token.startsWith('-'))
+      const exclusionTokens = tokens.filter(token => token.startsWith('-')).map(token => token.slice(1))
+      res = searchItems.filter(item => handleIncludeTokens(item, inclusionTokens) && handleExcludeTokens(item, exclusionTokens))
+    }
+
     return postProcess ? postProcess(res) : res
   })
 


### PR DESCRIPTION
SearchQuery is currently used for filtering:
- Search engine results
- Torrent content files
- Logs
- RSS Feeds / Articles
- Torrents (name and hash)

Example: Searching for /\d+p/ will filter all torrents containing a resolution in the name
- `/` will mark query as regex
- `\d+` will match one or more digits
- `p` will match the letter p

`1080p`, `720p`, `2160p`, ...

[Regexp Cheatsheet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet)