### PR TITLE
fix: "Checking auth status" toast not disappearing properly

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,9 +57,7 @@ const backendSyncObjects = [
 ]
 
 async function checkAuthentication() {
-  const promise = appStore.fetchAuthStatus()
-  const timer = setTimeout(() => void toast.promise(promise, { pending: t('login.pending') }), 1000)
-  return promise.then(() => clearTimeout(timer))
+  return toast.promise(appStore.fetchAuthStatus(), { pending: t('login.pending') })
 }
 
 function blockContextMenu(event: Event) {

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -20,16 +20,15 @@ export const useAppStore = defineStore('app', () => {
   }
 
   async function setAuthStatus(val: boolean, ver?: string) {
+    isAuthenticated.value = val
+
     if (val) {
-      isAuthenticated.value = val
       version.value = ver || (await qbit.getVersion())
       buildInfo.value = await qbit.getBuildInfo()
-      return
+    } else {
+      version.value = '0.0.0'
+      buildInfo.value = undefined
     }
-
-    isAuthenticated.value = val
-    version.value = '0.0.0'
-    buildInfo.value = undefined
   }
 
   function isFeatureAvailable(required_version?: string) {


### PR DESCRIPTION
Fixes #2097

Because of how everything is handled, it's better to just remove the delay and make the toast flash in case network is fast.