### PR TITLE
fix(SearchQuery): Allow text filtering on qbit prior to 4.4

### DIFF
--- a/src/composables/SearchQuery.spec.ts
+++ b/src/composables/SearchQuery.spec.ts
@@ -87,4 +87,10 @@ describe('composables/SearchQuery', () => {
     const { results } = useSearchQuery(items, '/\\d+/', item => item)
     expect(results.value).toEqual(items)
   })
+
+  test('should not fail with undefined values', () => {
+    const items = ['test1', 'test2', undefined, 'test3']
+    const { results } = useSearchQuery(items, 'test', item => item)
+    expect(results.value).toHaveLength(3)
+  })
 })

--- a/src/composables/SearchQuery.ts
+++ b/src/composables/SearchQuery.ts
@@ -1,10 +1,12 @@
 import { computed, MaybeRefOrGetter, toValue } from 'vue'
 import { normalize } from '@/helpers'
 
+type MaybeString = string | undefined
+
 export function useSearchQuery<T>(
   items: MaybeRefOrGetter<T[]>,
   searchQuery: MaybeRefOrGetter<string | null>,
-  getter: (item: T) => string | string[],
+  getter: (item: T) => MaybeString | MaybeString[],
   postProcess?: (items: T[]) => T[]
 ) {
   const results = computed(() => {
@@ -15,7 +17,7 @@ export function useSearchQuery<T>(
 
     if (query.startsWith('/') && query.endsWith('/')) {
       const regex = new RegExp(query.substring(1, query.length - 2))
-      res = searchItems.filter(item => [getter(item)].flat().some(singleItem => regex.test(singleItem)))
+      res = searchItems.filter(item => [getter(item)].flat().some(singleItem => regex.test(singleItem ?? '')))
     } else {
       const tokens = normalize(query).trim().split(/[ ,]/i).filter(Boolean)
       const inclusionTokens = tokens.filter(token => !token.startsWith('-'))

--- a/src/helpers/text.spec.ts
+++ b/src/helpers/text.spec.ts
@@ -266,8 +266,20 @@ test('helpers/text/codeToFlag', () => {
   expect(codeToFlag('it').url).toBe('https://cdn.jsdelivr.net/npm/twemoji/2/svg/1f1ee-1f1f9.svg')
 })
 
-test('helpers/text/normalize', () => {
-  expect(normalize('crème brûlée')).toBe('creme brulee')
-  expect(normalize('ąśćńżóźćęç')).toBe('ascnzozcec')
-  expect(normalize('áéíóú ÁÉÍÓÚ üÜ')).toBe('aeiou aeiou uu')
+describe('helpers/text/normalize', () => {
+  test('sample words', () => {
+    expect(normalize('crème brûlée')).toBe('creme brulee')
+  })
+
+  test('accents', () => {
+    expect(normalize('ąśćńżóźćęç')).toBe('ascnzozcec')
+  })
+
+  test('accents + uppercase', () => {
+    expect(normalize('áéíóú ÁÉÍÓÚ üÜ')).toBe('aeiou aeiou uu')
+  })
+
+  test('undefined values', () => {
+    expect(normalize(undefined)).toBe('')
+  })
 })

--- a/src/helpers/text.ts
+++ b/src/helpers/text.ts
@@ -108,9 +108,11 @@ export function codeToFlag(code: string) {
   }
 }
 
-export function normalize(data: string) {
-  return data
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/\p{Diacritic}/gu, '')
+export function normalize(data: string | undefined) {
+  return (
+    data
+      ?.toLowerCase()
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '') ?? ''
+  )
 }

--- a/src/types/vuetorrent/Torrent.ts
+++ b/src/types/vuetorrent/Torrent.ts
@@ -18,6 +18,7 @@ export default interface Torrent {
   content_path: string
   dl_limit: number
   dlspeed: number
+  /** @since 4.4.0 */
   download_path: string
   downloaded: number
   downloaded_session: number


### PR DESCRIPTION
Reported on Discord, introduced with #2504

When using qbit 4.3, the download_path field is undefined without it being specified in the Torrent type causing TS to pass type check but running into `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` at runtime