### PR TITLE
fix: "Checking auth status" toast

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,7 +87,6 @@ onBeforeMount(() => {
   vuetorrentStore.updateTheme()
   vuetorrentStore.setLanguage(language.value)
   addLaunchQueueConsumer()
-  void checkAuthentication()
 
   document.addEventListener('contextmenu', blockContextMenu)
 })
@@ -95,6 +94,8 @@ onBeforeMount(() => {
 onMounted(() => {
   // Global error handler flag
   sessionStorage.setItem('vuetorrent_mounted', 'true')
+
+  void checkAuthentication()
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
#2097

From the video on Discord, I think it happens because the toast and requests work are done before first page render. Depending on the hardware and state of the browser, the race condition is real this time, compared to the first 1 sec timeout.

I'll give a shot by waiting for that first page render before doing anything, this may flash the login page but I guess it's less of a problem then having a toast blocking a part of the screen 