### PR TITLE
fix: Delay login.pending toast.remove until opened

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,9 +56,11 @@ const backendSyncObjects = [
 
 async function checkAuthentication() {
   const p = appStore.fetchAuthStatus()
-  toast.loading(t('login.pending'), { 
+  toast.loading(t('login.pending'), {
     toastId: 'login-pending',
-    onOpen: () => p.then(() => toast.remove('login-pending'))
+    onOpen: () => {
+      void p.finally(() => toast.remove('login-pending'))
+    },
   })
   await p
 }


### PR DESCRIPTION
fix(#2097): Fix race in `login-pending` toast

The `login-pending` toast in `checkAuthentication` may call `toast.remove` too early before the toast has actually opened (since `toast.loading` returns as soon as the toast is queued but before it is guaranteed to be open).

If `fetchAuthStatus` resolves before the queued toast is opened, the `toast.remove` is called too early and the it remains permanently opened.

There is an `onOpen` callback that is deferred until the toast is opened (and therefore can be removed). By checking the `fetchAuthStatus` promise inside this callback and only then attempting to call remove fixes the race condition. If the promise is already resolved by the time the toast opens, it will resolve and remove it immediately.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
