### PR TITLE
fix: prevent "Checking current auth"  toast flicker

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -55,14 +55,16 @@ const backendSyncObjects = [
 ]
 
 async function checkAuthentication() {
-  const p = appStore.fetchAuthStatus()
-  toast.loading(t('login.pending'), {
-    toastId: 'login-pending',
-    onOpen: () => {
-      void p.finally(() => toast.remove('login-pending'))
-    },
-  })
-  await p
+  const authStatus = appStore.fetchAuthStatus()
+  const timer = setTimeout(() => {
+    toast.loading(t('login.pending'), {
+      toastId: 'login-pending',
+      onOpen: () => {
+        void authStatus.finally(() => toast.remove('login-pending'))
+      },
+    })
+  }, 1000)
+  await authStatus.finally(() => clearTimeout(timer))
 }
 
 function blockContextMenu(event: Event) {


### PR DESCRIPTION
As discussed here https://github.com/VueTorrent/VueTorrent/pull/2534#issuecomment-3393491418, adds a 1s timer before showing the check auth toast to prevent flicker.

Effectively reverting https://github.com/VueTorrent/VueTorrent/pull/2495 as the toast can now be consistently cleared.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
