### PR TITLE
Feat: Color coded connection status icon

### DIFF
--- a/src/components/Navbar/SideWidgets/BottomActions.vue
+++ b/src/components/Navbar/SideWidgets/BottomActions.vue
@@ -27,6 +27,20 @@ const connectionStatusIcon = computed(() => {
       return 'mdi-help-network'
   }
 })
+
+const connectionStatusClass = computed(() => {
+  switch (maindataStore.serverState?.connection_status) {
+    case ConnectionStatus.CONNECTED:
+      return 'text-success'
+    case ConnectionStatus.DISCONNECTED:
+      return 'text-error'
+    case ConnectionStatus.FIREWALLED:
+      return 'text-warning'
+    default:
+      return 'text-grey'
+  }
+})
+
 const connectionStatusText = computed(() => {
   let key
   switch (maindataStore.serverState?.connection_status) {
@@ -122,7 +136,7 @@ function openConfirmShutdownDialog() {
     <v-col class="d-flex justify-center">
       <v-tooltip :text="connectionStatusText" location="top">
         <template #activator="{ props }">
-          <v-btn variant="plain" :icon="connectionStatusIcon" v-bind="props" @click="openConnectionStatusDialog" />
+          <v-btn variant="plain" :icon="connectionStatusIcon" :class="connectionStatusClass" v-bind="props" @click="openConnectionStatusDialog" />
         </template>
       </v-tooltip>
     </v-col>


### PR DESCRIPTION
# Feat: Color coded connection status icon

Closes: #2458

Set the color of the connection status icon in the sidebar depending on the status.

Uses the same classes used in `ConnectionStatusDialog` component:

https://github.com/VueTorrent/VueTorrent/blob/f9876023efcc9912ea7575c744c3c53260a5cb08/src/components/Dialogs/ConnectionStatusDialog.vue#L16-L27

<img width="257" height="73" alt="Screenshot 2025-11-21 at 8 10 58 PM" src="https://github.com/user-attachments/assets/465387f7-fd76-4841-9dc2-0476a273e2bd" />
<img width="257" height="80" alt="Screenshot 2025-11-21 at 8 15 58 PM" src="https://github.com/user-attachments/assets/c0a2acc0-2af0-4a40-83bb-5fccdaa5cf46" />
<img width="259" height="85" alt="Screenshot 2025-11-21 at 8 16 09 PM" src="https://github.com/user-attachments/assets/bc3dcd45-1cc3-4e74-a53a-ea6432d4fd45" />



## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
