### PR TITLE
fix(PWA): Update handler when opening magnet links

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -38,7 +38,7 @@
   "protocol_handlers": [
     {
       "protocol": "magnet",
-      "url": "#/magnet/%s"
+      "url": "../#/magnet/%s"
     }
   ],
   "scope": "./",


### PR DESCRIPTION
Fixes #2570

Protocol handler URL is relative to the webmanifest path instead of the same root.