### PR TITLE
fix(ci): Repair actions after bump

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -166,6 +166,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
Recent bug that appeared after dependabot bumped actions/checkout to v6: d505e67628379f355638bcbcbac59729104188f2

Source: JamesIves/github-pages-deploy-action#1928
