### PR TITLE
Add name, version & time to settings export file name

### DIFF
--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -98,7 +98,10 @@ function downloadSettings() {
 
   const jsonString = JSON.stringify(JSON.parse(settings), null, 2)
   const blob = new Blob([jsonString], { type: 'application/json' })
-  downloadFile('settings.json', blob)
+  
+  const currentVersion = vueTorrentVersion.value
+  const currentTimestamp = new Date().toISOString()
+  downloadFile(`VueTorrent_${currentVersion}_${currentTimestamp}.json`, blob)
 }
 
 function importSettings() {


### PR DESCRIPTION
Fixes #2575

Changes the filename of the file downloaded from the "Export Settings" button.

Previously `settings.json`. 
Now `VueTorrent_<current VT version>_<current ISO UTC timestamp>.json`.

E.g. 
- `VueTorrent_DEV_2025-12-11T11_42_52.442Z.json`
- `VueTorrent_2.31.0_2025-12-11T11_58_52.274Z.json`

ISO string for the timestamp might be overkill, but for a settings file I think it suits. It's also time zone agnostic too which is nice.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
