### PR TITLE
fix: Improve URL detection

### DIFF
--- a/src/helpers/text.spec.ts
+++ b/src/helpers/text.spec.ts
@@ -188,6 +188,12 @@ describe('helpers/text/splitByUrl', () => {
     ])
   })
 
+  test('match filename as non-URL', () => {
+    expect(splitByUrl("Note: the file file_name_meta.xml contains metadata about this torrent's contents.")).toEqual([
+      { raw: "Note: the file file_name_meta.xml contains metadata about this torrent's contents.", isUrl: false },
+    ])
+  })
+
   test('match IPv6 URLs', () => {
     expect(splitByUrl('Connect to https://[2001:db8::1]:8080/path')).toEqual([
       { raw: 'Connect to ', isUrl: false },

--- a/src/helpers/text.ts
+++ b/src/helpers/text.ts
@@ -60,7 +60,7 @@ function getIpv6RegExp() {
  * Path (Optional): should match any string appended to the URL, excluding trailing punctuation like dots and commas
  */
 function getUrlRegExp() {
-  return /(?<protocol>(?:https?|udp):\/\/)?(?<host>[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}|\d{1,3}(?:\.\d{1,3}){3}|\[[a-fA-F0-9:]+])(?<port>:\d+)?(?<path>\/(?:\S*[^\s.,:;!?])?)?/gi
+  return /(?<protocol>(?:https?|udp):\/\/)?(?<host>(?<![_a-zA-Z0-9])[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}|\d{1,3}(?:\.\d{1,3}){3}|\[[a-fA-F0-9:]+])(?<port>:\d+)?(?<path>\/(?:\S*[^\s.,:;!?])?)?/gi
 }
 
 export function extractHostname(url: string): string {


### PR DESCRIPTION
Previous implementation would detect `meta.xml` as a URL. Added a look-behind group to not match if it is after underscores.