### PR TITLE
fix(lsio-mod): Fix invalid permissions on non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM scratch
-COPY /vuetorrent /vuetorrent
+COPY --chmod=555 /vuetorrent /vuetorrent


### PR DESCRIPTION
I guess this can be an issue if not running as root. It cannot hurt to set read flag explicitly on the other group.

Will try to reproduce before merging.

From #2370