### PR TITLE
perf(TorrentDetail): Change title to use torrent name

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1396,6 +1396,11 @@
       },
       "rootNode": "(Root)"
     },
+    "error": {
+      "content": "The torrent you are trying to access does not exist.",
+      "headline": "Invalid torrent ID",
+      "title": "Error"
+    },
     "info": {
       "boolean_values": "Boolean values",
       "data_values": "Data values",
@@ -1455,7 +1460,6 @@
       "categories": "Categories",
       "tags": "Tags"
     },
-    "title": "Torrent Detail",
     "trackers": {
       "addTrackers": {
         "newTrackers": "Tracker URLs to add",

--- a/src/pages/CookiesManager.vue
+++ b/src/pages/CookiesManager.vue
@@ -90,18 +90,15 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="pa-3">
-    <v-row no-gutters align="center" justify="center">
-      <v-col>
-        <h1 style="font-size: 1.6em !important" class="subtitle-1 ml-2">
-          {{ t('cookiesManager.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-btn icon="mdi-close" variant="plain" @click="goHome" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2">
+        {{ t('cookiesManager.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-btn icon="mdi-close" variant="plain" @click="goHome" />
+      </div>
+    </div>
 
     <v-card v-if="!cookies.length" :height="height">
       <v-empty-state :title="t('cookiesManager.empty.value')" color="accent" icon="mdi-cookie-off">

--- a/src/pages/Logs.vue
+++ b/src/pages/Logs.vue
@@ -87,27 +87,24 @@ onUnmounted(() => {
 
 <template>
   <div class="pa-3">
-    <v-row no-gutters align="center" justify="center">
-      <v-col>
-        <h1 style="font-size: 1.6em !important" class="subtitle-1 ml-2">
-          {{ t('logs.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-btn :icon="reverseSort ? 'mdi-sort-descending' : 'mdi-sort-ascending'" variant="plain" @click="reverseSort = !reverseSort" />
-          <v-btn icon="mdi-close" variant="plain" @click="goHome" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2">
+        {{ t('logs.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-btn :icon="reverseSort ? 'mdi-sort-descending' : 'mdi-sort-ascending'" variant="plain" @click="reverseSort = !reverseSort" />
+        <v-btn icon="mdi-close" variant="plain" @click="goHome" />
+      </div>
+    </div>
 
     <v-list>
       <v-list-item>
         <v-row>
           <v-col cols="6">
-            <v-select v-model="logTypeFilter" :items="logTypeOptions" :label="$t('logs.filters.type')" hide-details multiple chips>
+            <v-select v-model="logTypeFilter" :items="logTypeOptions" :label="t('logs.filters.type')" chips hide-details multiple>
               <template #prepend-item>
-                <v-list-item :title="$t('common.selectAll')" @click="toggleSelectAll">
+                <v-list-item :title="t('common.selectAll')" @click="toggleSelectAll">
                   <template #prepend>
                     <v-checkbox-btn :indeterminate="someTypesSelected && !allTypesSelected" :model-value="someTypesSelected" />
                   </template>
@@ -118,7 +115,7 @@ onUnmounted(() => {
           </v-col>
 
           <v-col cols="6">
-            <v-text-field v-model="logMessageFilter" :label="$t('logs.filters.query')" hide-details clearable />
+            <v-text-field v-model="logMessageFilter" :label="t('logs.filters.query')" clearable hide-details />
           </v-col>
         </v-row>
       </v-list-item>
@@ -154,7 +151,7 @@ onUnmounted(() => {
       </template>
 
       <v-list-item v-if="filteredLogs.length === 0">
-        {{ $t('logs.emptyLogList') }}
+        {{ t('logs.emptyLogList') }}
       </v-list-item>
 
       <v-divider />

--- a/src/pages/RssArticles.vue
+++ b/src/pages/RssArticles.vue
@@ -64,23 +64,20 @@ onUnmounted(() => {
 
 <template>
   <div class="pa-3">
-    <v-row align="center" justify="center" no-gutters>
-      <v-col>
-        <h1 class="subtitle-1 ml-2" style="font-size: 1.6em !important">
-          {{ feedsView ? $t('rssArticles.feeds.title') : $t('rssArticles.rules.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-tooltip :text="$t(feedsView ? 'rssArticles.toggle.rules' : 'rssArticles.toggle.feeds')" location="top">
-            <template #activator="{ props }">
-              <v-btn v-bind="props" icon="mdi-auto-download" variant="plain" @click="toggleFeedsView()" />
-            </template>
-          </v-tooltip>
-          <v-btn icon="mdi-close" variant="plain" @click="goHome()" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2">
+        {{ feedsView ? $t('rssArticles.feeds.title') : $t('rssArticles.rules.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-tooltip :text="$t(feedsView ? 'rssArticles.toggle.rules' : 'rssArticles.toggle.feeds')" location="top">
+          <template #activator="{ props }">
+            <v-btn icon="mdi-auto-download" v-bind="props" variant="plain" @click="toggleFeedsView()" />
+          </template>
+        </v-tooltip>
+        <v-btn icon="mdi-close" variant="plain" @click="goHome()" />
+      </div>
+    </div>
 
     <Feeds v-if="feedsView" :height="height" :mobile="mobile" @open-article="openRssArticle" />
     <Rules v-else :height="height" />

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -158,20 +158,17 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="pa-3">
-    <v-row no-gutters align="center" justify="center">
-      <v-col>
-        <h1 style="font-size: 1.6em !important" class="subtitle-1 ml-2">
-          {{ t('searchEngine.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-btn icon="mdi-stop" variant="plain" color="error" @click="stopAllSearch" />
-          <v-btn icon="mdi-toy-brick" variant="plain" color="primary" @click="openPluginManagerDialog" />
-          <v-btn icon="mdi-close" variant="plain" @click="goHome" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2">
+        {{ t('searchEngine.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-btn color="error" icon="mdi-stop" variant="plain" @click="stopAllSearch" />
+        <v-btn color="primary" icon="mdi-toy-brick" variant="plain" @click="openPluginManagerDialog" />
+        <v-btn icon="mdi-close" variant="plain" @click="goHome" />
+      </div>
+    </div>
 
     <v-row class="ma-0 pa-0">
       <v-container class="d-flex align-center justify-center ma-0 pa-0 bg-primary" fluid>
@@ -346,19 +343,19 @@ onBeforeUnmount(() => {
             {{ value === -1 ? t('common.NA') : formatTimeSec(value, dateFormat) }}
           </template>
           <template #[`item.actions`]="{ item }">
-            <v-tooltip :text="$t('searchEngine.tooltip.open_link')" location="top">
+            <v-tooltip :text="t('searchEngine.tooltip.open_link')" location="top">
               <template #activator="{ props }">
                 <v-btn v-bind="props" icon="mdi-open-in-new" variant="flat" density="compact" @click.stop="openResultLink(item)" />
               </template>
             </v-tooltip>
 
-            <v-tooltip :text="$t('searchEngine.tooltip.append_queue')" location="top">
+            <v-tooltip :text="t('searchEngine.tooltip.append_queue')" location="top">
               <template #activator="{ props }">
                 <v-btn v-bind="props" icon="mdi-plus-box-multiple" variant="text" density="compact" @click="pushToQueue(item)" />
               </template>
             </v-tooltip>
 
-            <v-tooltip :text="$t('searchEngine.tooltip.download')" location="top">
+            <v-tooltip :text="t('searchEngine.tooltip.download')" location="top">
               <template #activator="{ props }">
                 <v-btn
                   v-if="appStore.usesQbit5"

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -111,26 +111,23 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="pa-3">
-    <v-row no-gutters align="center" justify="center">
-      <v-col>
-        <h1 style="font-size: 1.6em !important" class="subtitle-1 ml-2">
-          {{ t('settings.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-btn color="accent" icon="mdi-content-save" variant="plain" @click="saveSettings" />
-          <v-btn icon="mdi-close" variant="plain" @click="goHome" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2">
+        {{ t('settings.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-btn color="accent" icon="mdi-content-save" variant="plain" @click="saveSettings" />
+        <v-btn icon="mdi-close" variant="plain" @click="goHome" />
+      </div>
+    </div>
 
     <v-row class="ma-0 pa-0">
       <v-tabs v-model="tab" bg-color="primary" grow show-arrows>
         <v-tab
           v-if="isEnhancedEdition"
           value="enhancedEdition"
-          :text="$t('settings.tabs.addons.enhanced_edition')"
+          :text="t('settings.tabs.addons.enhanced_edition')"
           replace
           :to="{ name: 'settings', params: { tab: 'enhancedEdition' } }" />
         <v-tab v-for="{ text, value } in tabs" :key="value" :value="value" :text="text" replace :to="{ name: 'settings', params: { tab: value } }" />

--- a/src/pages/TorrentCreator.vue
+++ b/src/pages/TorrentCreator.vue
@@ -134,18 +134,15 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="pa-3">
-    <v-row no-gutters align="center" justify="center">
-      <v-col>
-        <h1 style="font-size: 1.6em !important" class="subtitle-1 ml-2">
-          {{ t('torrentCreator.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-btn icon="mdi-close" variant="plain" @click="goHome" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2">
+        {{ t('torrentCreator.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-btn icon="mdi-close" variant="plain" @click="goHome" />
+      </div>
+    </div>
 
     <v-card v-if="!tasks.length" :height="height">
       <v-empty-state :title="t('torrentCreator.empty.value')" color="accent" icon="mdi-cog-off">

--- a/src/pages/TorrentDetail.vue
+++ b/src/pages/TorrentDetail.vue
@@ -101,22 +101,19 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="pa-3 text-select">
-    <v-row no-gutters align="center" justify="center">
-      <v-col>
-        <h1 style="font-size: 1.6em !important" class="subtitle-1 ml-2">
-          {{ t('torrentDetail.title') }}
-        </h1>
-      </v-col>
-      <v-col>
-        <div class="d-flex justify-end">
-          <v-btn icon="mdi-skip-previous" :disabled="isTorrentFilterEmpty || isFirstTorrent" variant="plain" @click="goToFirstTorrent" />
-          <v-btn icon="mdi-arrow-left" :disabled="isTorrentNotInFilter || isFirstTorrent" variant="plain" @click="goToPreviousTorrent" />
-          <v-btn icon="mdi-arrow-right" :disabled="isTorrentNotInFilter || isLastTorrent" variant="plain" @click="goToNextTorrent" />
-          <v-btn icon="mdi-skip-next" :disabled="isTorrentFilterEmpty || isLastTorrent" variant="plain" @click="goToLastTorrent" />
-          <v-btn icon="mdi-close" variant="plain" @click="goHome" />
-        </div>
-      </v-col>
-    </v-row>
+    <div class="d-flex align-center">
+      <div class="text-h5 ml-2 text-truncate">
+        {{ torrent?.name ?? t('torrentDetail.error.title') }}
+      </div>
+      <v-spacer />
+      <div class="d-flex justify-end">
+        <v-btn :disabled="isTorrentFilterEmpty || isFirstTorrent" icon="mdi-skip-previous" variant="plain" @click="goToFirstTorrent" />
+        <v-btn :disabled="isTorrentNotInFilter || isFirstTorrent" icon="mdi-arrow-left" variant="plain" @click="goToPreviousTorrent" />
+        <v-btn :disabled="isTorrentNotInFilter || isLastTorrent" icon="mdi-arrow-right" variant="plain" @click="goToNextTorrent" />
+        <v-btn :disabled="isTorrentFilterEmpty || isLastTorrent" icon="mdi-skip-next" variant="plain" @click="goToLastTorrent" />
+        <v-btn icon="mdi-close" variant="plain" @click="goHome" />
+      </div>
+    </div>
 
     <v-row class="ma-0 pa-0">
       <v-tabs v-model="tab" bg-color="primary" grow show-arrows>
@@ -145,6 +142,8 @@ onBeforeUnmount(() => {
       </v-window-item>
     </v-window>
   </div>
+
+  <v-empty-state v-if="!hash || !torrent" :headline="t('torrentDetail.error.headline')" :title="t('torrentDetail.error.content')" icon="mdi-alert-circle-outline" />
 
   <div :style="`position: absolute; left: ${contentStore.rightClickProperties.offset[0]}px; top: ${contentStore.rightClickProperties.offset[1]}px;`">
     <RightClickMenu v-model="contentStore.rightClickProperties.isVisible" :menu-data="contentStore.menuData" />


### PR DESCRIPTION
Fixes #2605

Title now uses focused torrent's name for easier navigation between torrents.

<img width="806" height="179" alt="image" src="https://github.com/user-attachments/assets/c73b3c8a-7f69-4c56-b87f-1a20173ac7fe" />

---

Also updated layout to display error message instead of having a blank screen.

<img width="1028" height="662" alt="image" src="https://github.com/user-attachments/assets/8bc3d875-1389-44d1-a1d8-7a86e58819b4" />
