### PR TITLE
fix(TorrentCreatorForm): set default private field to true

### DIFF
--- a/src/components/Dialogs/TorrentCreatorFormDialog.vue
+++ b/src/components/Dialogs/TorrentCreatorFormDialog.vue
@@ -26,7 +26,7 @@ const formData = reactive<Required<TorrentCreatorParams>>({
   pieceSize: 0,
   optimizeAlignment: false,
   paddedFileSizeLimit: 0,
-  private: false,
+  private: true,
   startSeeding: false,
   torrentFilePath: '',
   trackers: '',


### PR DESCRIPTION
Setting private flag to true at torrent creation is safer and avoids mis-announcing on DHT/PEX.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
