### PR TITLE
feat: download_path for categories

### DIFF
--- a/src/components/Dialogs/CategoryFormDialog.vue
+++ b/src/components/Dialogs/CategoryFormDialog.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { onBeforeMount, reactive, ref } from 'vue'
 import { VForm } from 'vuetify/components/VForm'
+import ServerPathField from '@/components/Core/ServerPathField.vue'
 import { useDialog, useI18nUtils } from '@/composables'
+import { HistoryKey } from '@/constants/vuetorrent'
 import { useCategoryStore } from '@/stores'
 import { Category } from '@/types/qbit/models'
 
@@ -21,14 +23,21 @@ const { isOpened } = useDialog(props.guid)
 const form = ref<VForm>()
 const isFormValid = ref(false)
 const nameRules = [(v: string) => !!v || t('dialogs.category.nameRequired')]
+const downloadPathField = ref<InstanceType<typeof ServerPathField>>()
+const savePathField = ref<InstanceType<typeof ServerPathField>>()
 
 const formData = reactive<Category>({
   name: '',
   savePath: '',
+  downloadPathEnabled: false,
+  downloadPath: '',
 })
 
 async function submit() {
   if (!isFormValid.value) return
+
+  savePathField.value?.saveValueToHistory()
+  downloadPathField.value?.saveValueToHistory()
 
   if (props.initialCategory) {
     await categoryStore.editCategory(formData, props.initialCategory.name === formData.name ? undefined : props.initialCategory.name)
@@ -48,6 +57,8 @@ function close() {
 onBeforeMount(() => {
   formData.name = props.initialCategory?.name || ''
   formData.savePath = props.initialCategory?.savePath || ''
+  formData.downloadPathEnabled = props.initialCategory?.downloadPathEnabled || false
+  formData.downloadPath = props.initialCategory?.downloadPath || ''
 })
 </script>
 
@@ -59,7 +70,23 @@ onBeforeMount(() => {
         <v-form ref="form" v-model="isFormValid" @submit.prevent @keydown.enter.prevent="submit">
           <v-text-field v-if="!!initialCategory" :model-value="initialCategory.name" disabled :label="$t('dialogs.category.oldName')" />
           <v-text-field v-model="formData.name" :rules="nameRules" :autofocus="!initialCategory" :label="$t('dialogs.category.name')" />
-          <v-text-field v-model="formData.savePath" :autofocus="!!initialCategory" :label="$t('dialogs.category.savePath')" />
+          <server-path-field ref="savePathField" v-model="formData.savePath" :history-key="HistoryKey.TORRENT_PATH" :title="t('dialogs.category.savePath')" hide-details>
+            <template #prepend>
+              <v-icon color="accent">mdi-content-save</v-icon>
+            </template>
+          </server-path-field>
+          <v-checkbox v-model="formData.downloadPathEnabled" hide-details density="compact" :label="t('dialogs.category.downloadPathEnabled')" />
+          <server-path-field
+            ref="downloadPathField"
+            v-model="formData.downloadPath"
+            :history-key="HistoryKey.TORRENT_PATH"
+            :title="t('dialogs.category.downloadPath')"
+            :disabled="!formData.downloadPathEnabled"
+            hide-details>
+            <template #prepend>
+              <v-icon color="accent">mdi-tray-arrow-down</v-icon>
+            </template>
+          </server-path-field>
           <v-scroll-x-transition>
             <div v-if="!!initialCategory && initialCategory.name !== formData.name" class="text-warning">
               <v-icon>mdi-alert</v-icon>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -353,6 +353,8 @@
       "unfold": "Expand"
     },
     "category": {
+      "downloadPath": "Incomplete torrent path",
+      "downloadPathEnabled": "Use another path for incomplete torrents",
       "name": "Category Name",
       "nameRequired": "Category name is required",
       "oldName": "Old category name",

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -46,11 +46,11 @@ export default class MockProvider implements IProvider {
     .fill('')
     .map((_, i) => (i + 1).toString(16).padStart(40, '0'))
   private readonly categories: Record<string, Category> = {
-    Movie: { name: 'Movie', savePath: faker.system.directoryPath() },
-    TV: { name: 'TV', savePath: faker.system.directoryPath() },
-    Other: { name: 'Other', savePath: faker.system.directoryPath() },
-    ISO: { name: 'ISO', savePath: faker.system.directoryPath() },
-    Music: { name: 'Music', savePath: faker.system.directoryPath() },
+    Movie: { name: 'Movie', savePath: faker.system.directoryPath(), download_path: faker.system.directoryPath() },
+    TV: { name: 'TV', savePath: faker.system.directoryPath(), download_path: faker.system.directoryPath() },
+    Other: { name: 'Other', savePath: faker.system.directoryPath(), download_path: faker.system.directoryPath() },
+    ISO: { name: 'ISO', savePath: faker.system.directoryPath(), download_path: faker.system.directoryPath() },
+    Music: { name: 'Music', savePath: faker.system.directoryPath(), download_path: false },
   }
   private readonly tags: string[] = ['pending', 'sorted', 'pending_sort']
   private readonly trackers: Record<string, string[]> = faker.helpers

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -740,6 +740,8 @@ export default class QBitProvider implements IProvider {
     return this.post('/torrents/createCategory', {
       category: cat.name,
       savePath: cat.savePath,
+      downloadPath: cat.downloadPath,
+      downloadPathEnabled: cat.downloadPathEnabled && cat.downloadPath !== '',
     }).then(res => res.data)
   }
 
@@ -754,6 +756,8 @@ export default class QBitProvider implements IProvider {
     const params = {
       category: cat.name,
       savePath: cat.savePath,
+      downloadPath: cat.downloadPath,
+      downloadPathEnabled: cat.downloadPathEnabled && cat.downloadPath !== '',
     }
 
     return this.post('/torrents/editCategory', params).then(res => res.data)

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -42,15 +42,19 @@ export const useCategoryStore = defineStore('categories', () => {
     for (const [catName, qbitCat] of entries) {
       const oldCat = _categoryMap.value.get(catName)
       if (oldCat) {
-        const newCat = {
+        const newCat: Category = {
           name: qbitCat.name ?? oldCat.name,
           savePath: qbitCat.savePath ?? oldCat.savePath,
+          downloadPathEnabled: qbitCat.download_path !== undefined ? qbitCat.download_path !== false : oldCat.downloadPathEnabled,
+          downloadPath: qbitCat.download_path !== undefined ? (typeof qbitCat.download_path === 'string' ? qbitCat.download_path : '') : oldCat.downloadPath,
         }
         _categoryMap.value.set(catName, newCat)
       } else {
         _categoryMap.value.set(catName, {
           name: qbitCat.name ?? catName,
           savePath: qbitCat.savePath ?? '',
+          downloadPathEnabled: qbitCat.download_path !== undefined && qbitCat.download_path !== false,
+          downloadPath: typeof qbitCat.download_path === 'string' ? qbitCat.download_path : '',
         })
       }
     }
@@ -73,7 +77,7 @@ export const useCategoryStore = defineStore('categories', () => {
       await qbit.createCategory(category)
 
       // Move old category torrent to new location
-      await qbit.editCategory({ name: oldCategory, savePath: category.savePath })
+      await qbit.editCategory({ name: oldCategory, savePath: category.savePath, downloadPathEnabled: category.downloadPathEnabled, downloadPath: category.downloadPath })
 
       // Get list of torrents in old category and move them to new category
       const torrents = await qbit.getTorrents({ category: oldCategory })

--- a/src/types/qbit/models/Category.ts
+++ b/src/types/qbit/models/Category.ts
@@ -1,4 +1,7 @@
 export default interface Category {
   name: string
   savePath: string
+  downloadPathEnabled?: boolean
+  downloadPath?: string
+  download_path?: string | boolean | undefined
 }


### PR DESCRIPTION
# download_path for categories [feat]

this PR introduces the option to have download_path for categories section

due to how the data is returned in maindata endpoint we have to handle the maindataSync function differently.

i have raised the issue on [qbittorrent/qBittorrent:23780](https://github.com/qbittorrent/qBittorrent/issues/23780)

closes #2617

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
