### PR TITLE
fix(SearchEngine): UI not receiving updates

### DIFF
--- a/src/stores/searchEngine.ts
+++ b/src/stores/searchEngine.ts
@@ -1,6 +1,6 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { v4 as uuidv4 } from 'uuid'
-import { ref, shallowRef, triggerRef } from 'vue'
+import { ref } from 'vue'
 import qbit from '@/services/qbit'
 import { SearchPlugin } from '@/types/qbit/models'
 import { SearchData } from '@/types/vuetorrent'
@@ -8,7 +8,7 @@ import { SearchData } from '@/types/vuetorrent'
 export const useSearchEngineStore = defineStore(
   'searchEngine',
   () => {
-    const searchData = shallowRef<SearchData[]>([])
+    const searchData = ref<SearchData[]>([])
     const searchPlugins = ref<SearchPlugin[]>([])
 
     function createNewTab() {
@@ -26,7 +26,6 @@ export const useSearchEngineStore = defineStore(
         results: [],
         timer: null,
       })
-      triggerRef(searchData)
     }
 
     function deleteTab(uniqueId: string) {
@@ -38,14 +37,11 @@ export const useSearchEngineStore = defineStore(
       tab.id = searchJob.id
       tab.results = []
       tab.lastQuery = tab.query
-      triggerRef(searchData)
     }
 
     async function refreshResults(tab: SearchData) {
       const response = await qbit.getSearchResults(tab.id, tab.results.length)
-
       tab.results.push(...response.results)
-      triggerRef(searchData)
 
       return response.status
     }
@@ -53,7 +49,6 @@ export const useSearchEngineStore = defineStore(
     async function stopSearch(tab: SearchData) {
       if (tab.id && tab.id !== 0) await qbit.stopSearch(tab.id)
       tab.id = 0
-      triggerRef(searchData)
     }
 
     async function fetchSearchPlugins() {


### PR DESCRIPTION
Fix #2676

Extracting tab and calling `triggerRef` in `refreshResults` doesn't force UI update as expected.

This PR rollbacks `shallowRef` change introduced with #2669 assuming that the results' content are quite simple and there may not be as much data as in other views.
