### PR TITLE
chore(ci): Use latest node version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 'latest'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 'latest'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 'latest'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Would cause warnings for some deps. Using latest to prevent future ones as well.