### PR TITLE
fix(RSS): Update article only showing in first feed match

### DIFF
--- a/src/components/RSS/Feeds/ArticleList.vue
+++ b/src/components/RSS/Feeds/ArticleList.vue
@@ -20,10 +20,10 @@ const addTorrentStore = useAddTorrentStore()
 const rssStore = useRssStore()
 const vuetorrentStore = useVueTorrentStore()
 
-const selectedFeed = computed(() => route.params.feedId)
+const selectedFeed = computed(() => route.params.feedId as string | undefined)
 
 const articles = computed(() =>
-  rssStore.filteredArticles.filter(article => !selectedFeed.value || selectedFeed.value === article.feedId).sort((a, b) => Number(b.parsedDate) - Number(a.parsedDate))
+  rssStore.filteredArticles.filter(article => !selectedFeed.value || article.feedIds.includes(selectedFeed.value)).sort((a, b) => Number(b.parsedDate) - Number(a.parsedDate))
 )
 
 const { paginatedResults, currentPage, pageCount } = useArrayPagination(articles, 15)

--- a/src/components/RSS/Feeds/FeedList.vue
+++ b/src/components/RSS/Feeds/FeedList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useArrayUnique } from '@vueuse/core'
 import { computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import Feed from './Feed.vue'
 import FeedIcon from './FeedIcon.vue'
 import { FeedState } from '@/constants/vuetorrent'
@@ -20,16 +20,17 @@ const emit = defineEmits<{
   refreshFeed: [feed: FeedType]
 }>()
 
+const route = useRoute()
 const router = useRouter()
 const rssStore = useRssStore()
 
 const currentFeed = computed({
-  get: () => router.currentRoute.value.params.feedId as string | undefined,
+  get: () => route.params.feedId as string | undefined,
   set(feedId) {
     void router.replace({ name: 'rssArticles', params: { tab: 'feeds', feedId } }).then(() => emit('update', feedId))
   },
 })
-const filteredFeedIds = useArrayUnique(() => rssStore.filteredArticles.map(art => art.feedId))
+const filteredFeedIds = useArrayUnique(() => rssStore.filteredArticles.flatMap(art => art.feedIds).flat())
 
 function getUnreadCount(feed?: FeedType) {
   if (!feed) {

--- a/src/stores/rss.ts
+++ b/src/stores/rss.ts
@@ -115,13 +115,16 @@ export const useRssStore = defineStore(
             existingFeedNames.push(feed.name)
 
             const existingArticle = articleMap.get(article.id)
-            if (existingArticle && !article.isRead) {
-              existingArticle.isRead = false
+            if (existingArticle) {
+              existingArticle.feedIds.push(feed.uid)
+              if (!article.isRead) {
+                existingArticle.isRead = false
+              }
             }
           } else {
             tempKeyMap.set(article.id, [feed.name])
             const rssArticle: RssArticle = {
-              feedId: feed.uid,
+              feedIds: [feed.uid],
               parsedDate: new Date(article.date),
               ...article,
             }

--- a/src/types/vuetorrent/RssArticle.ts
+++ b/src/types/vuetorrent/RssArticle.ts
@@ -2,7 +2,7 @@ import { FeedArticle } from '@/types/qbit/models'
 
 export interface RssArticle extends FeedArticle {
   /** UID of the parent feed */
-  feedId: string
+  feedIds: string[]
   /** Article publication date parsed by dayjs */
   parsedDate: Date
 }


### PR DESCRIPTION
When an RSS article appears on multiple feed, it only shows up in the first feed.