### PR TITLE
fix(Cookies): No cookies were imported

### DIFF
--- a/src/stores/cookies.ts
+++ b/src/stores/cookies.ts
@@ -44,12 +44,11 @@ export const useCookieStore = defineStore('cookies', () => {
   }
 
   async function importCookies(cookies: Cookie[], syncData: boolean = false) {
-    cookies.forEach(cookie => {
-      void removeCookie(cookie).then(() => addCookie(cookie))
-    })
+    const cookiePromise = Promise.all(cookies.map(cookie => removeCookie(cookie).then(() => addCookie(cookie))))
     if (syncData) {
-      await syncCookies()
+      return cookiePromise.then(() => syncCookies())
     }
+    return cookiePromise
   }
 
   return {


### PR DESCRIPTION
Promise orchestration is causing issues while importing cookies.

1. `removeCookie`, then adds all `addCookie` calls to promise queue
2. `syncCookies`
3. Resolve all pending `addCookie` calls

Thus causing an empty list when syncing cookies with qbit.

Everything is now running in the correct order inside a single Promise pipeline.