### PR TITLE
enhancement: export settings tooltip and error on no export

### DIFF
--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -104,11 +104,14 @@ function resetSettings() {
 
 function downloadSettings() {
   const settings = localStorage.getItem('vuetorrent_webuiSettings')
-  if (!settings) return
+  if (!settings) {
+    toast.warn(t('toast.export.no_settings'))
+    return
+  }
 
   const jsonString = JSON.stringify(JSON.parse(settings), null, 2)
   const blob = new Blob([jsonString], { type: 'application/json' })
-  
+
   const currentVersion = vueTorrentVersion.value
   const currentTimestamp = new Date().toISOString()
   downloadFile(`VueTorrent_${currentVersion}_${currentTimestamp}.json`, blob)
@@ -329,9 +332,14 @@ function openDurationFormatHelp() {
           </v-btn>
         </v-col>
         <v-col cols="12" sm="4" class="d-flex align-center justify-center">
-          <v-btn color="primary" @click="downloadSettings">
-            {{ t('settings.vuetorrent.general.download') }}
-          </v-btn>
+          <v-tooltip location="bottom">
+            <template #activator="{ props }">
+              <v-btn color="primary" v-bind="props" @click="downloadSettings">
+                {{ t('settings.vuetorrent.general.download') }}
+              </v-btn>
+            </template>
+            {{ t('settings.vuetorrent.general.exportTooltip') }}
+          </v-tooltip>
         </v-col>
         <v-col cols="12" sm="4" class="d-flex align-center justify-center">
           <v-btn color="red" @click="resetSettings">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1174,6 +1174,7 @@
         "defaultTorrentDetailTab": "Default Torrent Detail Tab",
         "displayGraphLimits": "Display limits in graph",
         "download": "Export settings",
+        "exportTooltip": "Exports VueTorrent-specific settings including theme, language, dashboard layout, and display preferences.",
         "durationFormat": "Duration format",
         "enableHashColors": "Enable generated chip colors",
         "enableRatioColors": "Enable ratio colors",
@@ -1301,6 +1302,9 @@
     },
     "copy": {
       "success": "Copied to clipboard!"
+    },
+    "export": {
+      "no_settings": "No VueTorrent settings found to export. Please configure some settings first."
     },
     "magnet_handler": {
       "not_supported": "Current context isn't secure. Unable to register handler.",


### PR DESCRIPTION
# export settings tooltip and error on no export [feat]

1. adds tooltip to export settings to explain the purpose of the button is to export vuetorrent based settings.
<img width="873" height="127" alt="Screenshot 2026-04-06 at 2 53 23 AM" src="https://github.com/user-attachments/assets/ae78ef63-59f7-48c8-bb0c-d9b9b18662ef" />

2. Adds error tost when user tries to export setting while not making any changes in settings
<img width="619" height="178" alt="Screenshot 2026-04-06 at 2 53 40 AM" src="https://github.com/user-attachments/assets/0427f8e8-946d-48d6-91f2-c72d4ae20a4f" />

Closes #2657

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
