### PR TITLE
chore(deps): bump vuetify from 3.11.8 to 4.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "vue3-apexcharts": "^1.11.1",
         "vue3-toastify": "^0.2.9",
         "vuedraggable": "^4.1.0",
-        "vuetify": "^3.11.8"
+        "vuetify": "^4.0.5"
       },
       "devDependencies": {
         "@dword-design/eslint-plugin-import-alias": "^8.1.8",
@@ -10006,9 +10006,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.11.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.11.8.tgz",
-      "integrity": "sha512-4iKnntOnLFFklygZjzlVfcHrtLO8+iK4HOhiia6HP2U8v82x+ngaSCgm+epvPrGyCMfCpfuEttqD2qElrr1axw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.0.5.tgz",
+      "integrity": "sha512-pFysKOHuY3dROTVh9PdlhVz50ZR0E5/goY5ecTXc8F8tajUA2ee3xZ8Lqs1WtEw/X3w93wx/LogyjgaQCAL/Ig==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vue3-apexcharts": "^1.11.1",
     "vue3-toastify": "^0.2.9",
     "vuedraggable": "^4.1.0",
-    "vuetify": "^3.11.8"
+    "vuetify": "^4.0.5"
   },
   "devDependencies": {
     "@dword-design/eslint-plugin-import-alias": "^8.1.8",

--- a/src/components/TorrentDetail/PieceCanvas.vue
+++ b/src/components/TorrentDetail/PieceCanvas.vue
@@ -26,6 +26,11 @@ const lastGraphics = shallowRef<Graphics>()
 const cachedPieces = ref<PieceState[]>([])
 const isPieceCanvasOverviewOpened = ref(false)
 
+function getThemeColor(colorName: string) {
+  const colorValue = theme.current.value.colors[colorName]
+  return typeof colorValue === 'string' ? colorValue : colorName
+}
+
 async function renderCanvas() {
   if (renderCanvasRunning.value || !canvas.value || !app.value) return
 
@@ -46,9 +51,9 @@ async function renderCanvas() {
     const state = cachedPieces.value[i]
     let newColor = ''
 
-    if (state === PieceState.DOWNLOADING) newColor = theme.current.value.colors['torrent-downloading']
-    else if (state === PieceState.DOWNLOADED) newColor = theme.current.value.colors['torrent-ul_stopped']
-    else if (state === PieceState.MISSING && selectedRanges.intersect_any([i, i])) newColor = theme.current.value.colors['torrent-dl_stopped']
+    if (state === PieceState.DOWNLOADING) newColor = getThemeColor('torrent-downloading')
+    else if (state === PieceState.DOWNLOADED) newColor = getThemeColor('torrent-ul_stopped')
+    else if (state === PieceState.MISSING && selectedRanges.intersect_any([i, i])) newColor = getThemeColor('torrent-dl_stopped')
 
     if (newColor === color) {
       ++rectWidth


### PR DESCRIPTION
# bump vuetify from 3.11.8 to 4.0.5 [chore]

Bumps [vuetify](https://github.com/vuetifyjs/vuetify/tree/HEAD/packages/vuetify) from 3.11.8 to 4.0.5.

closes #2728

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Vuetify to 4.0.5 to align the app with the latest UI framework.

* **Bug Fixes**
  * Improved canvas color handling for piece visualization so theme color values are interpreted safely, preventing occasional incorrect colors or display inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->