### PR TITLE
feat: add customizable logout URL for reverse proxy auth

### DIFF
--- a/src/components/Navbar/SideWidgets/BottomActions.vue
+++ b/src/components/Navbar/SideWidgets/BottomActions.vue
@@ -69,6 +69,12 @@ const themeIcon = computed(() => {
 
 async function logout() {
   await appStore.logout()
+
+  if (vueTorrentStore.logoutUrl) {
+    window.location.href = vueTorrentStore.logoutUrl
+    return
+  }
+
   await vueTorrentStore.redirectToLogin()
 }
 

--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -285,6 +285,15 @@ function openDurationFormatHelp() {
             append-inner-icon="mdi-help-circle"
             @click:append-inner="openDurationFormatHelp" />
         </v-col>
+
+        <v-col cols="12" md="12">
+          <v-text-field
+            v-model="vueTorrentStore.logoutUrl"
+            flat
+            hide-details
+            :label="t('settings.vuetorrent.general.logoutUrl')"
+            placeholder="https://auth.example.com/logout" />
+        </v-col>
       </v-row>
     </v-list-item>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1204,7 +1204,8 @@
         "useBinarySize": "Replace data sizes by binary units (kB -> KiB)",
         "useBitSpeed": "Replace speed values by bits (kB/s -> kbps)",
         "useEmojiState": "Prepend torrent states with emojis",
-        "vueTorrentTitle": "Tab title"
+        "vueTorrentTitle": "Tab title",
+        "logoutUrl": "Logout URL (leave empty for default behavior)"
       },
       "sidebar": {
         "CurrentSpeed": "Show Current Speed",

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -52,6 +52,7 @@ export const useVueTorrentStore = defineStore(
     const reduceMotion = ref(false)
     const keepDefaultTransitions = computed(() => !reduceMotion.value)
     const defaultTorrentDetailTab = ref(TorrentDetailTab.LAST_OPENED)
+    const logoutUrl = ref('')
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
     const _doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -280,6 +281,7 @@ export const useVueTorrentStore = defineStore(
       reduceMotion,
       keepDefaultTransitions,
       defaultTorrentDetailTab,
+      logoutUrl,
       $reset: () => {
         language.value = 'en'
         theme.mode = ThemeMode.SYSTEM
@@ -308,6 +310,7 @@ export const useVueTorrentStore = defineStore(
         expandContent.value = true
         reduceMotion.value = false
         defaultTorrentDetailTab.value = TorrentDetailTab.LAST_OPENED
+        logoutUrl.value = ''
 
         _busyProperties.value = JSON.parse(JSON.stringify(propsData))
         _doneProperties.value = JSON.parse(JSON.stringify(propsData))


### PR DESCRIPTION
add customizable logout URL for reverse proxy auth [ feat ]

Closes #2706

Adds the ability to customize the logout button URL. Useful when qBittorrent is behind a reverse proxy with external authentication (e.g., Authentik, Traefik).

When a custom logout URL is set:
1. Logs out from qBittorrent (revokes session cookies)
2. Redirects to the custom URL (e.g., external auth logout endpoint)

If no URL is set, behaves as before (redirects to qBittorrent login page).

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customizable logout URL setting in the VueTorrent configuration panel, enabling users to specify a custom destination for redirect upon logout. When configured, the application navigates to the specified URL after logout; if left empty, the default login redirect behavior is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->