### PR TITLE
perf(PWA): Cache fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <link rel="icon" href="favicon.ico" sizes="48x48">
     <link rel="icon" href="icon.svg" sizes="any" type="image/svg+xml">
     <link rel="apple-touch-icon" href="apple-touch-icon-180x180.png">
+    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   </head>
 
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -231,6 +231,22 @@ export default defineConfig(({ mode }) => {
         useCredentials: true,
         workbox: {
           cleanupOutdatedCaches: true,
+          runtimeCaching: [
+            {
+              urlPattern: ({ request }) => request.destination === 'font',
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'font-cache',
+                expiration: {
+                  maxEntries: 20,
+                  maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+                },
+                cacheableResponse: {
+                  statuses: [200],
+                },
+              },
+            },
+          ],
         },
       }),
     ],


### PR DESCRIPTION
Following #2740, fonts were not cached because not included in the public folder, but injected in the final build by NPM packages.