### PR TITLE
fix(TableView): Update CSS rule priority after #2743

### DIFF
--- a/src/components/Dashboard/Views/Table/TableView.vue
+++ b/src/components/Dashboard/Views/Table/TableView.vue
@@ -120,31 +120,33 @@ function getTorrentRowColorClass(torrent: TorrentType) {
 </template>
 
 <style lang="scss">
-#torrentList {
-  background-color: unset;
+@layer vuetify-components {
+  #torrentList {
+    background-color: unset;
 
-  tbody tr:nth-child(even) {
-    background-color: rgb(var(--v-theme-surface));
-  }
-
-  tbody tr.selected {
-    position: relative;
-
-    &:nth-child(odd)::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
+    tbody tr:nth-child(even) {
+      background-color: rgb(var(--v-theme-surface));
     }
-  }
 
-  .torrent-name {
-    max-width: 40vw;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    tbody tr.selected {
+      position: relative;
+
+      &:nth-child(odd)::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+      }
+    }
+
+    .torrent-name {
+      max-width: 40vw;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Vuetify updated their CSS system to use layers in V4.

Assigned correct layer so that `background-color` is taking correct precedence.

[MDN: @layer - CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer)
[CSS Layers - Vuetify](https://vuetifyjs.com/en/styles/layers/)