### PR TITLE
fix(PWA): Handle reverse proxy auth setup after #2740

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -231,7 +231,12 @@ export default defineConfig(({ mode }) => {
         useCredentials: true,
         workbox: {
           cleanupOutdatedCaches: true,
+          globIgnores: ['**/index.html'],
           runtimeCaching: [
+            {
+              urlPattern: ({ request }) => request.mode === 'navigate',
+              handler: 'NetworkOnly',
+            },
             {
               urlPattern: ({ request }) => request.destination === 'font',
               handler: 'CacheFirst',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -232,6 +232,7 @@ export default defineConfig(({ mode }) => {
         workbox: {
           cleanupOutdatedCaches: true,
           globIgnores: ['**/index.html'],
+          navigateFallback: undefined,
           runtimeCaching: [
             {
               urlPattern: ({ request }) => request.mode === 'navigate',


### PR DESCRIPTION
Because `index.html` was precached by default, requests that initiate auth flow when using forward auth on reverse proxy were not reaching the reverse proxy but were served by the service worker's precache.

This change effectively disable precache on all "navigate" requests (direct browser navigation network requests) to allow for proper redirection when needed.
